### PR TITLE
Fix Dependabot security alerts and rewrite release script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,14 +1953,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2013,6 +2010,76 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui/react": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.1.0.tgz",
+      "integrity": "sha512-ikcJRNj1mOiF2HZ5jQHrXoVoHcNHdBU5ejJljcBl+VTLoYXR6FidjTN86GjO6hyshi6TZFuNvv0dEOgaOFv6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@base-ui/utils": "0.2.4",
+        "@floating-ui/react-dom": "^2.1.6",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "tabbable": "^6.4.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.4.tgz",
+      "integrity": "sha512-smZwpMhjO29v+jrZusBSc5T+IJ3vBb9cjIiBjtKcvWmRj9Z4DWGVR3efr1eHR56/bqY5a4qyY9ElkOY5ljo3ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -2020,34 +2087,40 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@cacheable/memoize": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.3.tgz",
-      "integrity": "sha512-hl9wfQgpiydhQEIv7fkjEzTGE+tcosCXLKFDO707wYJ/78FVOlowb36djex5GdbSyeHnG62pomYLMuV/OT8Pbw==",
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
+      "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/utils": "^2.0.3"
+        "@cacheable/utils": "^2.3.3",
+        "@keyv/bigmap": "^1.3.0",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
       }
     },
-    "node_modules/@cacheable/memory": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.3.tgz",
-      "integrity": "sha512-R3UKy/CKOyb1LZG/VRCTMcpiMDyLH7SH3JrraRdK6kf3GweWCOU3sgvE13W3TiDRbxnDKylzKJvhUAvWl9LQOA==",
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memoize": "^2.0.3",
-        "@cacheable/utils": "^2.0.3",
-        "@keyv/bigmap": "^1.0.2",
-        "hookified": "^1.12.1",
-        "keyv": "^5.5.3"
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/memory/node_modules/keyv": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-      "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2055,19 +2128,20 @@
       }
     },
     "node_modules/@cacheable/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-ZdxfOiaarMqMj+H7qwlt5EBKWaeGihSYVHdQv5lUsbn8MJJOTW82OIwirQ39U5tMZkNvy3bQE+ryzC+xTAb9/g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
+      "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "keyv": "^5.5.3"
+        "hashery": "^1.3.0",
+        "keyv": "^5.5.5"
       }
     },
     "node_modules/@cacheable/utils/node_modules/keyv": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-      "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2096,6 +2170,23 @@
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
       }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -2148,6 +2239,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@date-fns/utc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+      "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2166,6 +2264,40 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/JounQin"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2449,13 +2581,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2467,19 +2592,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/js": {
@@ -2520,22 +2632,24 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -2552,10 +2666,11 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
-      "dev": true
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",
@@ -2737,6 +2852,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2759,6 +2884,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -2802,6 +2941,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -3016,9 +3162,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3197,19 +3343,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@keyv/bigmap": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.0.3.tgz",
-      "integrity": "sha512-jUEkNlnE9tYzX2AIBeoSe1gVUvSOfIOQ5EFPL5Un8cFHGvjD9L/fxpxlS1tEivRLHgapO2RZJ3D93HYAa049pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hookified": "^1.12.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -3222,6 +3355,19 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -3520,9 +3666,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3764,9 +3910,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3842,9 +3988,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
-      "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4202,13 +4348,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
-      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.56.0"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4218,19 +4364,18 @@
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.11.tgz",
-      "integrity": "sha512-7j/6vdTym0+qZ6u4XbSAxrWBGYSdCfTzySkj7WAFgDLmSyWlOrWvpyzxlFh5jtw9dn0oL/jtW+06XfFiisN3JQ==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
+        "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
         "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
         "loader-utils": "^2.0.4",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       },
       "engines": {
@@ -4242,7 +4387,7 @@
         "sockjs-client": "^1.4.0",
         "type-fest": ">=0.17.0 <5.0.0",
         "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
       },
@@ -4267,6 +4412,63 @@
         }
       }
     },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -4283,9 +4485,9 @@
       "dev": true
     },
     "node_modules/@preact/signals": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.2.tgz",
-      "integrity": "sha512-naxcJgUJ6BTOROJ7C3QML7KvwKwCXQJYTc5L/b0eEsdYgPB6SxwoQ1vDGcS0Q7GVjAenVq/tXrybVdFShHYZWg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.3.tgz",
+      "integrity": "sha512-FieIS2Z3iHAmjYTqsD3U3DEad1/bOicGN8wT34bbrdp422kQfkP7iwYgqTgx53wPdnsENaNkNNmScbi3RVZq8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4300,9 +4502,9 @@
       }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
-      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
+      "integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4449,6 +4651,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
@@ -4461,6 +4687,30 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4503,6 +4753,30 @@
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4563,6 +4837,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-presence": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
@@ -4589,13 +4887,13 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-slot": "1.2.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4608,6 +4906,25 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -4794,9 +5111,9 @@
       "license": "MIT"
     },
     "node_modules/@sentry/core": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.46.0.tgz",
-      "integrity": "sha512-it7JMFqxVproAgEtbLgCVBYtQ9fIb+Bu0JD+cEplTN/Ukpe6GaolyYib5geZqslVxhp2sQgT+58aGvfd/k0N8Q==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4804,9 +5121,9 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.46.0.tgz",
-      "integrity": "sha512-pRLqAcd7GTGvN8gex5FtkQR5Mcol8gOy1WlyZZFq4rBbVtMbqKOQRhohwqnb+YrnmtFpj7IZ7KNDo077MvNeOQ==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+      "integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4840,9 +5157,9 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.34.0",
         "@prisma/instrumentation": "6.11.1",
-        "@sentry/core": "9.46.0",
-        "@sentry/node-core": "9.46.0",
-        "@sentry/opentelemetry": "9.46.0",
+        "@sentry/core": "9.47.1",
+        "@sentry/node-core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
         "import-in-the-middle": "^1.14.2",
         "minimatch": "^9.0.0"
       },
@@ -4851,14 +5168,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.46.0.tgz",
-      "integrity": "sha512-XRVu5pqoklZeh4wqhxCLZkz/ipoKhitctgEFXX9Yh1e1BoHM2pIxT52wf+W6hHM676TFmFXW3uKBjsmRM3AjgA==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+      "integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.46.0",
-        "@sentry/opentelemetry": "9.46.0",
+        "@sentry/core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
         "import-in-the-middle": "^1.14.2"
       },
       "engines": {
@@ -4901,13 +5218,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.46.0.tgz",
-      "integrity": "sha512-w2zTxqrdmwRok0cXBoh+ksXdGRUHUZhlpfL/H2kfTodOL+Mk8rW72qUmfqQceXoqgbz8UyK8YgJbyt+XS5H4Qg==",
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+      "integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.46.0"
+        "@sentry/core": "9.47.1"
       },
       "engines": {
         "node": ">=18"
@@ -5304,6 +5621,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/history": {
+      "version": "1.154.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.154.14.tgz",
+      "integrity": "sha512-xyIfof8eHBuub1CkBnbKNKQXeRZC4dClhmzePHVOEel4G7lk/dW+TQ16da7CFdeNLv6u6Owf5VoBQxoo6DFTSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-core": {
+      "version": "1.158.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.158.1.tgz",
+      "integrity": "sha512-8B9X3GzN1JWsqa+OTgg2k+LrayLQYmgtv26b96difyrRS32DaDBvEpU3xXDaLNmi/+zoqG1ffAcDT4D6tyC2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.154.14",
+        "@tanstack/store": "^0.8.0",
+        "cookie-es": "^2.0.0",
+        "seroval": "^1.4.2",
+        "seroval-plugins": "^1.4.2",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.8.0.tgz",
+      "integrity": "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -5327,6 +5692,17 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -5580,12 +5956,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "version": "20.19.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
+      "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -5720,16 +6097,6 @@
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/simple-peer": {
-      "version": "9.11.8",
-      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.8.tgz",
-      "integrity": "sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
@@ -7130,9 +7497,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7179,6 +7546,275 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
@@ -7406,31 +8042,128 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.32.0.tgz",
-      "integrity": "sha512-FNoyQUO1wAf768MX2vMNNk1Il3bi/A7c1s9WKSaufwEZEViXjWeqqb9GO6stWkur4UP9MRcv8IpWoLXi1BePHA==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.39.0.tgz",
+      "integrity": "sha512-uFy3FIF6MOo67tTVC2SaNyBQbFafu+DRirt2/IUQlY7w2MOiXWPaQFi3Oyy81gc8TfsooSFBlK4lrujd7O4gEw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/dom-ready": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0"
+        "@wordpress/dom-ready": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/api-fetch": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
-      "integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+    "node_modules/@wordpress/admin-ui": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-1.7.0.tgz",
+      "integrity": "sha512-jhmq40xQhLGZDR/GDq0HQ+zAg+YeH4YGUmS6LCUzV2SBtqJmpucKfflQY+TTwJGSWM6luFrUw5NSDrA9QcMgTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/url": "^4.32.0"
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/route": "^0.5.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/admin-ui/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/admin-ui/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/api-fetch": {
+      "version": "7.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.39.0.tgz",
+      "integrity": "sha512-H6ysbEgDYuIDhvRje1iTyC9r4bEOY9AT0fRmNEr6fSG/furznt4XNtoflzh4Q4DeaC2flTQ9hn46JgcmW3IXJA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/url": "^4.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7438,34 +8171,31 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.32.0.tgz",
-      "integrity": "sha512-JD1JmCE2gEWBikF9zHCFb8j6Az6AdXeuZjg3Ewyk9vlAfU8bADRXEwVslFM0p8UD/TtK3Zzw7Rj1B0B4Lf8W6g==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.39.0.tgz",
+      "integrity": "sha512-plqVet/sQD+AVZk4UXlgUUX7CwqGr6lkgn6SY7JlgYrxDq0BsYm1oZ+bHKOHuhSzO83F8P8A24IIHS5yVYnKzQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.32.0.tgz",
-      "integrity": "sha512-K6sbRuLpLQWDnIhg0FRWuHOV68BMsrPrNeMNt1TcFDOMCqozI/mnfwCbejfIO7ZPqJtbfucnh1OQ9EkMWPibew==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.39.0.tgz",
+      "integrity": "sha512-H5rheT+rrXuPb9+ey5LemC8g4i5uGVndpalboEQHaXVpLII9B283+ZmtQZy1We1RdIyVXD6MB2EtSXt8R4oKuw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "7.25.7",
+        "@babel/plugin-syntax-import-attributes": "7.26.0",
         "@babel/plugin-transform-react-jsx": "7.25.7",
         "@babel/plugin-transform-runtime": "7.25.7",
         "@babel/preset-env": "7.25.7",
         "@babel/preset-typescript": "7.25.7",
-        "@babel/runtime": "7.25.7",
-        "@wordpress/browserslist-config": "^6.32.0",
-        "@wordpress/warning": "^3.32.0",
+        "@wordpress/browserslist-config": "^6.39.0",
+        "@wordpress/warning": "^3.39.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.0"
@@ -7473,6 +8203,22 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@wordpress/babel-preset-default/node_modules/react": {
@@ -7489,9 +8235,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.8.0.tgz",
-      "integrity": "sha512-x3LCQ4DuIOg58LyQRZtI6shmNKCk2zuKGwIEMH7h7MMri/Q95ehR6Sub8dKiUL4AHktdlweouJwbHaqrXPkd0Q==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+      "integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7500,62 +8246,61 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.32.0.tgz",
-      "integrity": "sha512-LcQMY5Rj0OczNnBU+w+kvJJ9htsOChpoq7uMdTMqz7Oj8QmC+laIkpkX9Ds72Vkck1uaPDpFofw6wcC5KY3h+A==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.39.0.tgz",
+      "integrity": "sha512-TK3mevvKKidK/k6fROdEHF3n5tCAsnsvLRe2qasPYfhxVN1mBLFrYn506KqZgC42Xibd+fzDN3m9voldg0VeLQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.5.0.tgz",
-      "integrity": "sha512-wyqhR7kE7vknEfxdHw5LIJrk7jR3I4WtO31TLKaIIK7gEaUS1eTAH6RNNu8UxJGhXP7PL7ogOb7q2bhd6eEmGA==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.12.0.tgz",
+      "integrity": "sha512-E59sSKnucc9tOMwWx7tFzjbpysc1Ob12NSF109oLMwhp/kGvtsXvxdv4NvO9BfPwoiHglSnxVfbrpdDOBujtSw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@emotion/react": "^11.7.1",
-        "@emotion/styled": "^11.6.0",
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/blob": "^4.32.0",
-        "@wordpress/block-serialization-default-parser": "^5.32.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/commands": "^1.32.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/date": "^5.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/dom": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/escape-html": "^3.32.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/is-shallow-equal": "^5.32.0",
-        "@wordpress/keyboard-shortcuts": "^5.32.0",
-        "@wordpress/keycodes": "^4.32.0",
-        "@wordpress/notices": "^5.32.0",
-        "@wordpress/preferences": "^4.32.0",
-        "@wordpress/priority-queue": "^3.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/rich-text": "^7.32.0",
-        "@wordpress/style-engine": "^2.32.0",
-        "@wordpress/token-list": "^3.32.0",
-        "@wordpress/upload-media": "^0.17.0",
-        "@wordpress/url": "^4.32.0",
-        "@wordpress/warning": "^3.32.0",
-        "@wordpress/wordcount": "^4.32.0",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/blob": "^4.39.0",
+        "@wordpress/block-serialization-default-parser": "^5.39.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/commands": "^1.39.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/dataviews": "^11.3.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/global-styles-engine": "^1.6.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/image-cropper": "^1.3.0",
+        "@wordpress/interactivity": "^6.39.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keyboard-shortcuts": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/preferences": "^4.39.0",
+        "@wordpress/priority-queue": "^3.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/style-engine": "^2.39.0",
+        "@wordpress/token-list": "^3.39.0",
+        "@wordpress/upload-media": "^0.24.0",
+        "@wordpress/url": "^4.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "@wordpress/wordcount": "^4.39.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -7580,53 +8325,131 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-library": {
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.32.0.tgz",
-      "integrity": "sha512-Q5+gKQcaqdUBgxDIbUo8FgapH1vwRE2J2eH5eXmKtoM++Nx94yOZDQumo+0yWluInsCgXBcVKpqCSxireKwu4g==",
+    "node_modules/@wordpress/block-editor/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/autop": "^4.32.0",
-        "@wordpress/blob": "^4.32.0",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/core-data": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/date": "^5.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/dom": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/escape-html": "^3.32.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/interactivity": "^6.32.0",
-        "@wordpress/interactivity-router": "^2.32.0",
-        "@wordpress/keyboard-shortcuts": "^5.32.0",
-        "@wordpress/keycodes": "^4.32.0",
-        "@wordpress/notices": "^5.32.0",
-        "@wordpress/patterns": "^2.32.0",
-        "@wordpress/primitives": "^4.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/reusable-blocks": "^5.32.0",
-        "@wordpress/rich-text": "^7.32.0",
-        "@wordpress/server-side-render": "^6.8.0",
-        "@wordpress/url": "^4.32.0",
-        "@wordpress/viewport": "^6.32.0",
-        "@wordpress/wordcount": "^4.32.0",
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
-        "escape-html": "^1.0.3",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library": {
+      "version": "9.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.39.0.tgz",
+      "integrity": "sha512-gWQyujSWLM4E90C0o5wdedgw1mlRHsa6ExYmYAWi77ts1Ok/nqgJK5KOI/lyYiiWKCowaljIJ9GBVdQYjgzpZg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/autop": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/blob": "^4.39.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/interactivity": "^6.39.0",
+        "@wordpress/interactivity-router": "^2.39.0",
+        "@wordpress/keyboard-shortcuts": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/latex-to-mathml": "^1.7.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/patterns": "^2.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/reusable-blocks": "^5.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/server-side-render": "^6.15.0",
+        "@wordpress/url": "^4.39.0",
+        "@wordpress/viewport": "^6.39.0",
+        "@wordpress/wordcount": "^4.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
         "fast-average-color": "^9.1.1",
         "fast-deep-equal": "^3.1.3",
+        "html-react-parser": "5.2.11",
         "memize": "^2.1.0",
         "remove-accents": "^0.5.0",
         "uuid": "^9.0.1"
@@ -7640,43 +8463,116 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.32.0.tgz",
-      "integrity": "sha512-Rim243Fc2snGskZiKuBgi25MJQ9u81ngdMo7w1VZ7r/uqd6KrRr8CC1sY8hwop7ritCeGMFTEDAiD6ARuycmNw==",
+    "node_modules/@wordpress/block-library/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.39.0.tgz",
+      "integrity": "sha512-X2lFTu3Wq4QlKwA0YzTmzD3yX7dhi6lz+Xv+ki/qXpXUXGTS0H191uqgjDKGm7Y6qSVlgP1QTF26sAxRC56RwA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.5.0.tgz",
-      "integrity": "sha512-RxJGBtjgyjDd79H4TEbGfy6N6JU1KLMyWzgjzrmScoZghFOBeWI4qHvqud9pr01A3i9IGhQ72j0QvvgQdtWhhA==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.12.0.tgz",
+      "integrity": "sha512-YYqStbtsvOirbl8KMd5gmhUa9nK5iXo17XCq0mP5QIV0RFgjBTKIPoYANX1fT4vPG3N5bXnza0Jgxbd94unfLA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/autop": "^4.32.0",
-        "@wordpress/blob": "^4.32.0",
-        "@wordpress/block-serialization-default-parser": "^5.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/dom": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/is-shallow-equal": "^5.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/rich-text": "^7.32.0",
-        "@wordpress/shortcode": "^4.32.0",
-        "@wordpress/warning": "^3.32.0",
+        "@wordpress/autop": "^4.39.0",
+        "@wordpress/blob": "^4.39.0",
+        "@wordpress/block-serialization-default-parser": "^5.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/shortcode": "^4.39.0",
+        "@wordpress/warning": "^3.39.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "fast-deep-equal": "^3.1.3",
@@ -7698,9 +8594,9 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.32.0.tgz",
-      "integrity": "sha512-8NemosyPrey1yswd6LH8vX9mcRF6Xmqt2mKUCspnmEX4KvayyezmtJPh2EQo3GfySVHGWePzb0yfMYEqDdsC0Q==",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.39.0.tgz",
+      "integrity": "sha512-fHVG274KKjgAyF7ruvKe+H2JXKh3T7wh3jMrLYoIUx39Hr/LfjYbnsVqWaUDyRhx4nLnk0XIpBfGc+38TDuROQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7709,20 +8605,20 @@
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.32.0.tgz",
-      "integrity": "sha512-csVqkLoGw73i4plSMVx1t5pXFdFk8D9vJQJRzJWtdWiy8aMM+/1Yx3YetTAY/YD62mYOGk4FtkkhF/3ijaQUqQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.39.0.tgz",
+      "integrity": "sha512-zNFvNyfv+/mLFa+kPcAtrdPscj2XT+9eVMzS9jN645hcFQZdep6YhSGkaK6jVw9Vu+qTsw04o31Q8PaWejI9Mw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/keyboard-shortcuts": "^5.32.0",
-        "@wordpress/private-apis": "^1.32.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/keyboard-shortcuts": "^5.39.0",
+        "@wordpress/private-apis": "^1.39.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -7735,15 +8631,92 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/components": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.5.0.tgz",
-      "integrity": "sha512-LIu96PI14RpwABd5iDyTI8OxlDVEbDfX/6UUctTKsSqfJWTAynIL/K/JIHhxxI2wYbtut9yu8nugwFCPdconvA==",
+    "node_modules/@wordpress/commands/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
-        "@babel/runtime": "7.25.7",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/components": {
+      "version": "30.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+      "integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
@@ -7754,23 +8727,24 @@
         "@types/gradient-parser": "1.1.0",
         "@types/highlight-words-core": "1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/date": "^5.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/dom": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/escape-html": "^3.32.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/is-shallow-equal": "^5.32.0",
-        "@wordpress/keycodes": "^4.32.0",
-        "@wordpress/primitives": "^4.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/rich-text": "^7.32.0",
-        "@wordpress/warning": "^3.32.0",
+        "@wordpress/a11y": "^4.36.0",
+        "@wordpress/base-styles": "^6.12.0",
+        "@wordpress/compose": "^7.36.0",
+        "@wordpress/date": "^5.36.0",
+        "@wordpress/deprecated": "^4.36.0",
+        "@wordpress/dom": "^4.36.0",
+        "@wordpress/element": "^6.36.0",
+        "@wordpress/escape-html": "^3.36.0",
+        "@wordpress/hooks": "^4.36.0",
+        "@wordpress/html-entities": "^4.36.0",
+        "@wordpress/i18n": "^6.9.0",
+        "@wordpress/icons": "^11.3.0",
+        "@wordpress/is-shallow-equal": "^5.36.0",
+        "@wordpress/keycodes": "^4.36.0",
+        "@wordpress/primitives": "^4.36.0",
+        "@wordpress/private-apis": "^1.36.0",
+        "@wordpress/rich-text": "^7.36.0",
+        "@wordpress/warning": "^3.36.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -7799,21 +8773,20 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.32.0.tgz",
-      "integrity": "sha512-y4StIlClJiijBHduZ6Bx0tfFarsNi6hc+mvPk2ENIfNNLHf0P90f97XjbvUUr0U1J92x7silHliQfdF0ygbFQg==",
+      "version": "7.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.39.0.tgz",
+      "integrity": "sha512-9VyaqEDojUEnXKVxNamamEyYrWuI9vc2r33iV7hAe+8W0ISujRAFXp/baDiSOlYAcsbauRD4yAkEXuM0C4Vyhg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/dom": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/is-shallow-equal": "^5.32.0",
-        "@wordpress/keycodes": "^4.32.0",
-        "@wordpress/priority-queue": "^3.32.0",
-        "@wordpress/undo-manager": "^1.32.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/priority-queue": "^3.39.0",
+        "@wordpress/undo-manager": "^1.39.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -7828,29 +8801,28 @@
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.32.0.tgz",
-      "integrity": "sha512-cHcEhoucu5YhPTpo2I+NVlxINPMTnh8cXcfrBmrqAnwFA5MttMhF8av9lnz6k3ieY9eB99rY+BDcE09+jkRl7w==",
+      "version": "7.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.39.0.tgz",
+      "integrity": "sha512-ri5Csowaq6Er7nM1skUl+8fC4SyZ0pKqghaINnU0A2BKlmyCC+K4adb8CGkK1t5EsvZEzI5x6I8Gb8jpBigAiQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/is-shallow-equal": "^5.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/rich-text": "^7.32.0",
-        "@wordpress/sync": "^1.32.0",
-        "@wordpress/undo-manager": "^1.32.0",
-        "@wordpress/url": "^4.32.0",
-        "@wordpress/warning": "^3.32.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/sync": "^1.39.0",
+        "@wordpress/undo-manager": "^1.39.0",
+        "@wordpress/url": "^4.39.0",
+        "@wordpress/warning": "^3.39.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -7867,20 +8839,19 @@
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.32.0.tgz",
-      "integrity": "sha512-7lReC2/qVxlQVYVlqIYfZ9Irbzo6W30iuiD67xaXqVxiD9BA8CePY2dTBpCsykBkczoT0ryerVp648SvY82R9Q==",
+      "version": "10.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.39.0.tgz",
+      "integrity": "sha512-L04X/Vawzx6RgvvSQga8JhvPxr1A6seBrWJoRBBP7+1zdCV7nmmR8339yTEPRnCH6m70qb0xSwTByUmTzWYzLg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/is-shallow-equal": "^5.32.0",
-        "@wordpress/priority-queue": "^3.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/redux-routine": "^5.32.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/priority-queue": "^3.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/redux-routine": "^5.39.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -7898,27 +8869,30 @@
       }
     },
     "node_modules/@wordpress/dataviews": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-9.1.0.tgz",
-      "integrity": "sha512-F7l2td904Aoe8rfCULHOO33pVyPj4NfWjb1cSLoXF+5Ic0JXx7L9rsGNr7qx4b4w52TssrZ22XFgfd5jsR0w5w==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-11.3.0.tgz",
+      "integrity": "sha512-y3IT733p3ji7WoXm67WNWvy79bnSML3cMo2qvL1XPLl0cI1p6V7P2WC3TGRJdFKQl72I0Lph8pnRPtlUHJwwkw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
-        "@babel/runtime": "7.25.7",
-        "@wordpress/base-styles": "^6.8.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/date": "^5.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/keycodes": "^4.32.0",
-        "@wordpress/primitives": "^4.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/url": "^4.32.0",
-        "@wordpress/warning": "^3.32.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/theme": "^0.6.0",
+        "@wordpress/ui": "^0.6.0",
+        "@wordpress/url": "^4.39.0",
+        "@wordpress/warning": "^3.39.0",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
         "date-fns": "^4.1.0",
@@ -7935,6 +8909,94 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/dataviews/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/components/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/@wordpress/dataviews/node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -7947,14 +9009,13 @@
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.32.0.tgz",
-      "integrity": "sha512-hWmsDHzzmhbWAwWzBM042eItGor1up9tV0nEvjn1qdERoI/MS3+78d8vF40sMdWnXLNcPTCR+JHjD6kqJVmuXQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.39.0.tgz",
+      "integrity": "sha512-Wy8z+I0ZQjSTP/S4M9JqaDEUuucxGy70g+I8UCOFRgDFIO5v4hZVKo1uOH0NO5gGdlhmg4Scb9l9uzYVp8oqmg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.32.0",
+        "@wordpress/deprecated": "^4.39.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -7964,9 +9025,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.32.0.tgz",
-      "integrity": "sha512-05XLzLx+cTXgid6/qI6XzBclNvkLIi9F0oLAn4htL1ExIXLfc9yBSNcNkVVP7Tr5pmpMq0NUxfM58jqxxmFfCQ==",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.39.0.tgz",
+      "integrity": "sha512-5NSKdRd2o+qBkcx6SDaHG1Ow/EkT578SgVsRzzz3BwSRSvUee8+oDYq4SmtNIqRr7Fz5AOONL5jaluMPJBwlbQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7988,14 +9049,13 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.32.0.tgz",
-      "integrity": "sha512-HfHXUWfe/lyXTvJLWjpMJ90+XzmC2l/9vcp05n2tD+nsxwF5nS0Hjf+38pQtFPBcw3d1bbzMTNahDjtNBLvKTQ==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.39.0.tgz",
+      "integrity": "sha512-/vTXUsh2MGOuh8nhzgpBKIKsbgdtgjE2hFiCPw8rP4wwEbKUlxhNdtZdqkaumNtZywfHbRUBWO9xTpAVX17XfA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.32.0"
+        "@wordpress/hooks": "^4.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8003,14 +9063,13 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.32.0.tgz",
-      "integrity": "sha512-TphAq3bE34R5O0qW2q1SSBGdqfjTtHQSxzjKc0ufvTJf1nVZkJpCOqAP0Bue48AwfFYQSagdD3RgqYjcPPEMYg==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.39.0.tgz",
+      "integrity": "sha512-PCZVqTIV3V797rjWxZYoBJ+5g8girPZB0GzKZWxgsB6Y/+bS5OvBCJ70FgeZwO7oReo7ktXVNz/ZQMb5JsPosw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.32.0"
+        "@wordpress/deprecated": "^4.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8018,28 +9077,24 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.32.0.tgz",
-      "integrity": "sha512-Ru+gF3J37wiz33yqVoSmwPmc5afvGyujxyLvkGI0N4Y6EBMUmEJbC6QUbTOVld8RANQ0Bqu1btXMZfFYEY9PIQ==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.39.0.tgz",
+      "integrity": "sha512-qHhRnlSK0E2GTMo1D2gOtcr9FW11HG8X8lZLkmf3N0zhjem+MP7G15jFB7wophpypL3plnBHMxiDD6qUHh9dSg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.32.0.tgz",
-      "integrity": "sha512-w1hE7xDB06SQDfwtbggyU2xTyQ++GyU2wwEc648LL6OYLh7wlDuEzP/7XCrYbxA/GPGFDKCOL3uhU163F2N/Dw==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.39.0.tgz",
+      "integrity": "sha512-ok008Rd8URqNQCzx/9bClC+gk7XxVV+xm5rOJjb6A4EHR8tVlynJEcE4gN0C5qCDIeOdPLbGW8ljNm2DxlelwQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "change-case": "^4.1.2",
-        "form-data": "^4.0.0",
         "get-port": "^5.1.1",
         "lighthouse": "^12.2.2",
         "mime": "^3.0.0",
@@ -8050,45 +9105,48 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "@playwright/test": ">=1"
+        "@playwright/test": ">=1",
+        "@types/node": "^20.17.10"
       }
     },
     "node_modules/@wordpress/edit-post": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.32.0.tgz",
-      "integrity": "sha512-5BM/Ez8cjtvT5RXkG118zgqITvp1/hay0djbBuuwS1/c6+PQDq5VV3e4oVYv3ay1Lq9Wk81XAE7Ofz4nzDOKMQ==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.39.0.tgz",
+      "integrity": "sha512-VnqpFQCfTaut47f2tXIU0jb0trmUHtzl2sONPIOVD0BO3sVPdFL92+wz+GzKgnu+0me8GZSnrGoMwhxWDTW37w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/block-library": "^9.32.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/commands": "^1.32.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/core-data": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/dom": "^4.32.0",
-        "@wordpress/editor": "^14.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/keyboard-shortcuts": "^5.32.0",
-        "@wordpress/keycodes": "^4.32.0",
-        "@wordpress/notices": "^5.32.0",
-        "@wordpress/plugins": "^7.32.0",
-        "@wordpress/preferences": "^4.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/url": "^4.32.0",
-        "@wordpress/viewport": "^6.32.0",
-        "@wordpress/warning": "^3.32.0",
-        "@wordpress/widgets": "^4.32.0",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/admin-ui": "^1.7.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/block-library": "^9.39.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/commands": "^1.39.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/editor": "^14.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/global-styles-engine": "^1.6.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/keyboard-shortcuts": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/plugins": "^7.39.0",
+        "@wordpress/preferences": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/url": "^4.39.0",
+        "@wordpress/viewport": "^6.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "@wordpress/widgets": "^4.39.0",
         "clsx": "^2.1.1",
         "memize": "^2.1.0"
       },
@@ -8101,56 +9159,136 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/editor": {
-      "version": "14.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.32.0.tgz",
-      "integrity": "sha512-MZEY9gSFDzWGNEXneT90YzkgcduWVWuaQJqIKGR5G23FBmZUsZsC58mEGFepwDHB6W868ZGHyG91ZTPlXat+Jg==",
+    "node_modules/@wordpress/edit-post/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/edit-post/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/blob": "^4.32.0",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/commands": "^1.32.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/core-data": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/dataviews": "^9.1.0",
-        "@wordpress/date": "^5.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/dom": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/fields": "^0.24.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/interface": "^9.17.0",
-        "@wordpress/keyboard-shortcuts": "^5.32.0",
-        "@wordpress/keycodes": "^4.32.0",
-        "@wordpress/media-utils": "^5.32.0",
-        "@wordpress/notices": "^5.32.0",
-        "@wordpress/patterns": "^2.32.0",
-        "@wordpress/plugins": "^7.32.0",
-        "@wordpress/preferences": "^4.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/reusable-blocks": "^5.32.0",
-        "@wordpress/rich-text": "^7.32.0",
-        "@wordpress/server-side-render": "^6.8.0",
-        "@wordpress/url": "^4.32.0",
-        "@wordpress/warning": "^3.32.0",
-        "@wordpress/wordcount": "^4.32.0",
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/editor": {
+      "version": "14.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.39.0.tgz",
+      "integrity": "sha512-sSa3veA+FumdiGfWWW2XH+Uk1iShvpnbdD5CSlUy/h45G1Ut8ChtnR6VoAMx5AXOZO2M3t28XRBVCbeB9Ahc6w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@floating-ui/react-dom": "2.0.8",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/blob": "^4.39.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/commands": "^1.39.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/dataviews": "^11.3.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/fields": "^0.31.0",
+        "@wordpress/global-styles-engine": "^1.6.0",
+        "@wordpress/global-styles-ui": "^1.6.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/interface": "^9.24.0",
+        "@wordpress/keyboard-shortcuts": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/media-editor": "^0.2.0",
+        "@wordpress/media-fields": "^0.4.0",
+        "@wordpress/media-utils": "^5.39.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/patterns": "^2.39.0",
+        "@wordpress/plugins": "^7.39.0",
+        "@wordpress/preferences": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/reusable-blocks": "^5.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/server-side-render": "^6.15.0",
+        "@wordpress/url": "^4.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "@wordpress/wordcount": "^4.39.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
         "fast-deep-equal": "^3.1.3",
-        "is-plain-object": "^5.0.0",
         "memize": "^2.1.0",
         "react-autosize-textarea": "^7.1.0",
         "remove-accents": "^0.5.0",
@@ -8165,17 +9303,93 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/element": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.32.0.tgz",
-      "integrity": "sha512-W/Bw6HXzRBJgYYUdoUBUvtjXNWh8dVK8aqFsqpnEJTAiXdU8Ii0wBQ+E49bI/08yGCwsaXrLbQLXqtAiV6leMw==",
+    "node_modules/@wordpress/editor/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.32.0",
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/element": {
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+      "integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/escape-html": "^3.39.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8187,14 +9401,14 @@
       }
     },
     "node_modules/@wordpress/element/node_modules/@types/react": {
-      "version": "18.3.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@wordpress/element/node_modules/@types/react-dom": {
@@ -8235,33 +9449,31 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.32.0.tgz",
-      "integrity": "sha512-pT5wZmg9ob/u8RuSXgfZv8Kfd8zpvtBcCdcFE/UHasjtxJSecxDHFb0uI4eXQrSiTrsthbDZDlK/GIAagmt75Q==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.39.0.tgz",
+      "integrity": "sha512-YhAmZYQsOnnfafMwInzy/M1AR77O59u4aaIVSqiQjvCLkY+BQABsU6AizDckCg57mF2SoDnARl6xQY/7FCwEmw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "22.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.18.0.tgz",
-      "integrity": "sha512-1w4bhax+vg3xFDXs/z2jNRaCO/kagpK0ZZ6PGWH5Anlp+e9MuzQHMbcU6Xpd/+ZU118z0rJeXDvjb3QgEfvEOg==",
+      "version": "22.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.22.0.tgz",
+      "integrity": "sha512-DLGm5i8Gn0vjkZGKF49U2pYME5Jl9AvmoMJB2G508d+sB/oTSkPmM0baUP7G5zxbd1aqfNTaD0KjdyGyWFFKOA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "7.25.7",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^8.32.0",
-        "@wordpress/prettier-config": "^4.32.0",
+        "@wordpress/babel-preset-default": "^8.36.0",
+        "@wordpress/prettier-config": "^4.36.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-jest": "^27.4.3",
         "eslint-plugin-jsdoc": "^46.4.6",
@@ -8618,9 +9830,9 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8644,36 +9856,36 @@
       }
     },
     "node_modules/@wordpress/fields": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.24.0.tgz",
-      "integrity": "sha512-1GdI/WWuLRYnvmLF0us+7hSiUgEUSaI5Fp9xPKpUVVVa3pnh12lFUvNGlyWjWQjkRAihJWv1qOfiSedDvJSDuw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.31.0.tgz",
+      "integrity": "sha512-Fk2PgxvKwN6AhqlHwnyuGUQM8aw3KmuSixGmp2WyBJQw9nm/sNRf2HKs4NsQYgG6PFXdBJ69ItzJuFt214LQfA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/blob": "^4.32.0",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/core-data": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/dataviews": "^9.1.0",
-        "@wordpress/date": "^5.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/media-utils": "^5.32.0",
-        "@wordpress/notices": "^5.32.0",
-        "@wordpress/patterns": "^2.32.0",
-        "@wordpress/primitives": "^4.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/router": "^1.32.0",
-        "@wordpress/url": "^4.32.0",
-        "@wordpress/warning": "^3.32.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/blob": "^4.39.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/dataviews": "^11.3.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/media-utils": "^5.39.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/patterns": "^2.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/router": "^1.39.0",
+        "@wordpress/url": "^4.39.0",
+        "@wordpress/warning": "^3.39.0",
         "change-case": "4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "2.1.1",
@@ -8687,44 +9899,249 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/hooks": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.32.0.tgz",
-      "integrity": "sha512-aXCLsuOQJiVJDrVKV4MjGYeU2Nv8+pg2KSAzANs7OGXIl714Q968t5qODJiJ6ADsng3FnQ0pATVYBGBTGlW6Gg==",
+    "node_modules/@wordpress/fields/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/fields/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/global-styles-engine": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.6.0.tgz",
+      "integrity": "sha512-SlV6RwNrnbh3/0fE6kRdTZLt7Fj02sTNEnEMq1rKpr+P5i8ZYFXZj5nW2Mb4lPpLNCQ2DiKxDpo6TEtscrBnUw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/style-engine": "^2.39.0",
+        "colord": "^2.9.2",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/global-styles-ui": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.6.0.tgz",
+      "integrity": "sha512-nM47Nzj71EkgVzHMGKnt36yPMnRHwUj6fpZrrUqQWx4NhbIcasUK9OvdzSAtBf1QLjG5QYM6nTtDiNmVeNhWAw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/global-styles-engine": "^1.6.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.0",
+        "colord": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/global-styles-ui/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/hooks": {
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.39.0.tgz",
+      "integrity": "sha512-FTKdGF5jHHmC8GSO6/ATQqh1IFQeDwapRtlp7t4VaTGwZtX+uzawgq/7QDIhFi3cfg9hNsFF0CSFp/Ul3nEeUA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.32.0.tgz",
-      "integrity": "sha512-IHHxBeMIQR7/+Fq27eWEzOuBi10guTRBNVZUrdk32ZyJL2ISpVYwMiHOwKBH6J/67ayBSon23gUEWBqUE6bC9g==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.39.0.tgz",
+      "integrity": "sha512-gKpDo9vXxws4L03x6JYal8zrv+HjtQ4KMicpUdsHY8hhH5Asid2UGOBkCA1pQ1j9KVSWWj+3RsF0Ay1lem06Fw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.5.0.tgz",
-      "integrity": "sha512-VJ4QwkgKaVBk2+u6NYTMJ4jc/fave0Q2DAmoTN1AoSaHnK1Yuq9qJtBHAdkLUo7bBpRORBTl8OFFJTFLxgc9eA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+      "integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.32.0",
+        "@wordpress/hooks": "^4.39.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -8738,25 +10155,127 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "10.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.32.0.tgz",
-      "integrity": "sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+      "integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/primitives": "^4.32.0"
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/primitives": "^4.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/image-cropper": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.3.0.tgz",
+      "integrity": "sha512-uLHAT7WVYp4c6pP0A3XI9FZdK/ecVTw+BIt5WjRw7aKqn7ahFYptdLnKqZqA9eG50eJF3wYOFcE3w8D0/Uq4NQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "clsx": "^2.1.1",
+        "dequal": "^2.0.3",
+        "react-easy-crop": "^5.4.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.32.0.tgz",
-      "integrity": "sha512-acOMrgEPVwa08MhGZlrGwtsiOmAlTaHM6I4LD5ssEeUL5+Yc7PrwOqfqZ1Y8vPuifthUv1BQ1cJ1JeHBCOxaNg==",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.39.0.tgz",
+      "integrity": "sha512-9fjoPCOMdcwX1cGW2P4YBIK8LYkz9lhWHI8kgg4OCmBgkVuaFr+g43jjLojbD5bq2KPJYiQ1bD+hGJcgg4zPeQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -8769,14 +10288,14 @@
       }
     },
     "node_modules/@wordpress/interactivity-router": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.32.0.tgz",
-      "integrity": "sha512-3hVMD4nIEfBwPoZ2DXBzgCt/+rLnmflxgk8pnFLp3FBL69KwEoN92NuNEOID3HIQu3v1z/DElSbpuLZIyjHeZw==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.39.0.tgz",
+      "integrity": "sha512-Bf0EXQs/2tyfy1px18hIKZuPSE2pdIqm8SzmjiGwzrP0uz1bvfAeu3X3ADDN1VvN5RKbngFMv3Oe53OtTcQbNQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/interactivity": "^6.32.0",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/interactivity": "^6.39.0",
         "es-module-lexer": "^1.5.4"
       },
       "engines": {
@@ -8785,24 +10304,25 @@
       }
     },
     "node_modules/@wordpress/interface": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.17.0.tgz",
-      "integrity": "sha512-Y0jS2iNEAVC+1JlKjRwOyMEnFKmaSPehUZNnm2VsvTJIT4/W4GuQxOAE4GaEWa2+2aG7Jrr+NcH+HZOUXPdCEA==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.24.0.tgz",
+      "integrity": "sha512-HNt/e5TqQBlHFiaG1q0ISag8a9PeK1d2w9kuMdQcm5vGDr/fFwvY7AYRl3/CfxbR/goI38g/ZvLNV2jRmF2RPw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/plugins": "^7.32.0",
-        "@wordpress/preferences": "^4.32.0",
-        "@wordpress/viewport": "^6.32.0",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/admin-ui": "^1.7.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/plugins": "^7.39.0",
+        "@wordpress/preferences": "^4.39.0",
+        "@wordpress/viewport": "^6.39.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8814,29 +10334,103 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.32.0.tgz",
-      "integrity": "sha512-YabJ43zv30CU8kPhTrWQZhlatwO/fBo78/HvEU40CSGCRf+j9XKu9ZUidj3xDKgzLEkDCOKmj0vUY0+NyBbKzA==",
+    "node_modules/@wordpress/interface/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/interface/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.39.0.tgz",
+      "integrity": "sha512-v/yDkQj/VpdR8y4b0xNTeuFkfdU2AYf/0YABbry6GB6zG+mkPgi2+cglQ681V621korKOX6JRAsMQuRX6D2UNA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.32.0.tgz",
-      "integrity": "sha512-Sq4Ss0gJNmLzpJ9K/5Nto/FTV5L7ALvmdfA7b8JpmuKh32CETN4uIGDSfqS2a5Pfcg4KepwnL6jF9790uM54QA==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.39.0.tgz",
+      "integrity": "sha512-/fgtytFExodPPI3596s/zW8vf+7P56Oqw7AK1wQycfP1biemVQcXHYr4GKpHiahZsuHuYKr/FubmN36zs9SW0Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "jest-matcher-utils": "^29.6.2"
+        "jest-matcher-utils": "^29.6.2",
+        "jest-mock": "^29.6.2"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8847,13 +10441,13 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "12.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.32.0.tgz",
-      "integrity": "sha512-Y8X+0KCjUiB1MxxwridiY0Ku3iJVOTJSsutSReu+rM/hS/1azlBMctC0bqUyC0mQyBqPF0SNlpHjYdsAoVEznQ==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.39.0.tgz",
+      "integrity": "sha512-rFaz2wY88acg6TFiE4/goo0UBiLMgk0u+WaKd/nYO1Nk7sei0qromabEQO2LPJyAs0SZqbz3fFhcibueFMWFwA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^8.32.0",
+        "@wordpress/jest-console": "^8.39.0",
         "babel-jest": "29.7.0"
       },
       "engines": {
@@ -8866,16 +10460,15 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.32.0.tgz",
-      "integrity": "sha512-s33V1wNmlXTaUmVC8NOX06a7vU4UUuiwqaDeKZO6V3Y9U28b8NAr2tJeY8oFfctPX5aRWeOaYfAXqTMI4oU9KA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.39.0.tgz",
+      "integrity": "sha512-vTB9fTgsgWrCQbFQQCZqMWWTAj24ZhhfLvlN+JB3Vf417tWlRjd153XkTkEL3gu3UTWaCjwhtuyMVnEeV0Xwxw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/keycodes": "^4.32.0"
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/keycodes": "^4.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8886,49 +10479,352 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.32.0.tgz",
-      "integrity": "sha512-XzSc3uT+viVCdycT2W6/wu+d8NZaS2y0sdHZbPXIJ6hEbyyG7ncG+XDFhXckFggqXuajxkPTEJDwOtrSTxLYqw==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+      "integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.5.0"
+        "@wordpress/i18n": "^6.12.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/latex-to-mathml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.7.0.tgz",
+      "integrity": "sha512-QFJaJme4YW7dSqBdc9RWjGNBu/soauPK6DjjDKigDOuSgpkV389cnEN17e6mokXDgcWd06wzeoP6nYWeI3ylXQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "temml": "^0.10.33"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/media-editor": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-editor/-/media-editor-0.2.0.tgz",
+      "integrity": "sha512-efvZyS5vCigBM782plB5asjj8KE5WjitokiViAniSRuUDGkGWktsoL1DLoKh9pYK0yB32lPhy2vaNpnelRqCag==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/dataviews": "^11.3.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-fields": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.4.0.tgz",
+      "integrity": "sha512-dZ7QfV4DJpS05JT2R0PKc5zPYOCDl5ENRpDms+KFwvChiwE4WmQAAhnCEP0bd3KkFfwXQUU0tWp+ZTEpEbxfrQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/dataviews": "^11.3.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/url": "^4.39.0",
+        "clsx": "2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@wordpress/media-utils": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.32.0.tgz",
-      "integrity": "sha512-tDlOxyLSKbAZrVgQ92bp6MQHHD7gxTyfE8QmYjft55UaZDXOGo9Q5aLsQ+5PoU+ZuTwImvOpt0EBiO5I/PWa4A==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.39.0.tgz",
+      "integrity": "sha512-KXV+RhZaJVMQLxGurCNWl4K1cM8JWZU2eEVe4eosBQwFWy78mIjKUYOnsv8AGBDwaADw3YdB8KAJptpngh9THw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/blob": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/private-apis": "^1.32.0"
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/blob": "^4.39.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/dataviews": "^11.3.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/media-fields": "^0.4.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/private-apis": "^1.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/notices": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.32.0.tgz",
-      "integrity": "sha512-iyjAtp/UJUT46zKpBi/oX3iR8y1P7W/VqsvTitGUUeZIH9yBwaKgk5mroTABjgIgqUcC7p64i5cOGi9c23L5kA==",
+    "node_modules/@wordpress/media-utils/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/data": "^10.32.0"
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/notices": {
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.39.0.tgz",
+      "integrity": "sha512-a3RAmiVPr+U1863wKVgUVoIYP1rPRnlQNRghqexa38L6Ic9/V/YLY4tCeLmqAXXwWYb3ATx1eHwRKcPVfRt9qg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/data": "^10.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8939,9 +10835,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.32.0.tgz",
-      "integrity": "sha512-X3D9g0m0OIM6FfdHfmyGENOZG53kc+i49WuHnDnC1gZWV5Ai0SD/CNfRcPZOYw7Ld9CScrM3kqXAKG7nd1fGFg==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.39.0.tgz",
+      "integrity": "sha512-svfW7oLwTh6sRp42ATnr18H6wo1qibwercDEz2zsFg/LmWQ4h4agBhsiaDFdDFLgs7KbVwvZUzwgMvytBO9yAw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -8953,27 +10849,104 @@
       }
     },
     "node_modules/@wordpress/patterns": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.32.0.tgz",
-      "integrity": "sha512-UrkW1fS89P4SvLm8BXEu4+ENQwnuKF+ljC/Z4X0vhISpTdGxr05FAxzu04LhYl/He3WbfZOzhEDykSs1TzFilg==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.39.0.tgz",
+      "integrity": "sha512-ng12nb8dgfE3YJcd4ReHe+YyFnqzOpRh8bQcHE0zXFtuE/x6mJXMf3wE26h0JwGdsGDI8/Y1tOlI7TxKuv7Uvg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/core-data": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/html-entities": "^4.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/notices": "^5.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/url": "^4.32.0"
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/url": "^4.39.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/patterns/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8985,20 +10958,19 @@
       }
     },
     "node_modules/@wordpress/plugins": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.32.0.tgz",
-      "integrity": "sha512-y4On9jeMfbtkNj9TjSD8xhrbl/vxhVBXUwiLlzFOqecHp7ggHvxY4yINXS9nijQ+KQoGbg+74uxtM1XRYQ/Muw==",
+      "version": "7.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.39.0.tgz",
+      "integrity": "sha512-RDmKwpQlZf/SJNCx++NXaEz+FV0PyFg/PVP1pPtNSpNf7eq+s2hnbTcHqtXe1eVj5Z9VKJwzVumgVpcEnAxiqg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/hooks": "^4.32.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/is-shallow-equal": "^5.32.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
         "memize": "^2.0.1"
       },
       "engines": {
@@ -9010,15 +10982,93 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.32.0.tgz",
-      "integrity": "sha512-cJGgp8Z3o8dKfUWQZtQ/gNceYwLQET1z7RqkOAaSI5O0lelGit8gqpWeA7qYyZb9K1kWwhz8GGVWUIsQhCo2sQ==",
+    "node_modules/@wordpress/plugins/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/plugins/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.8.0",
-        "autoprefixer": "^10.4.20"
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/postcss-plugins-preset": {
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.39.0.tgz",
+      "integrity": "sha512-r1KaBbrQSnMNOiE58gGU66RxoksRxEIo87BSdEy2tOREUz9Eoa4NExzJmnTmuC786CjadlPsn95Q98x9OWDlNQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/base-styles": "^6.15.0",
+        "autoprefixer": "^10.4.20",
+        "postcss-import": "^16.1.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9029,22 +11079,22 @@
       }
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.32.0.tgz",
-      "integrity": "sha512-K2umcScb2efx028aFR9mbjW+p88kWp7C3CmdHOL00Gl8p4Hcl8N3eGUlYxs5CEaS0cCcwzL1eG9axL1TiskwOw==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.39.0.tgz",
+      "integrity": "sha512-4rUwrdglMKxGrru5l/JTEKsv7/ncsVQFxMtlG+VmFV2f/x/WboDDz2VGQwRO2/bOTyOM4KZJpZxeJ7E1Lo2B0A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/private-apis": "^1.32.0",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/private-apis": "^1.39.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -9056,10 +11106,87 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/preferences/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.32.0.tgz",
-      "integrity": "sha512-fS4Z5hXewajLKxbMQY4rdq3fSpUnwHHfLWqOJHXlu3u4rjqVf0VMJsLsSsSM8tV78rU6x6dWIEugG6CnDygYjA==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.39.0.tgz",
+      "integrity": "sha512-w9NPuyKZ8y7xLNRaXOK6TLw0HdcA9vQBmK65cd16w4WxyPwXwFVGBdwoi2og/RN3UBQLYci25zGp7GtiiVhG+Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -9071,14 +11198,13 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.32.0.tgz",
-      "integrity": "sha512-pf46CU5qQaGOULlAMNQTi+Jkwf1vwfrGYmkRtuTP68/Y8yOI19v5JZg/Vwq5nCHOs/L750mX1wMp4WvGWoPhFg==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.39.0.tgz",
+      "integrity": "sha512-RV9s+KzyuS8p0YKczLecmhFAtOHIWkCToHyDSmRf8N3XOy4id/T0+B5SJ2nMZJleG1oYINf5lrVcccqP2VmFJg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/element": "^6.32.0",
+        "@wordpress/element": "^6.39.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -9090,13 +11216,12 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.32.0.tgz",
-      "integrity": "sha512-LXlkiXxRSv35FBvjfAqn+rHH7KF4mw2wVl57SVzWglZAUdfvrcjrinRlEsqgMZxeAVeLPiutRV1qlkueZl7E8w==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.39.0.tgz",
+      "integrity": "sha512-IyiB5y55dIYJZnC5Vl3v2cKuRDR1hYSEA++fijpD4AJZTu+2bhtdN9PnmFE9T25WGzWqnfJEdBSHPglby9MhRA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "requestidlecallback": "^0.3.0"
       },
       "engines": {
@@ -9105,27 +11230,23 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.32.0.tgz",
-      "integrity": "sha512-xmc+U8tve6QmGKiYTwVutkPkqqJkvB2fvrimjMkw8TGpnzBcmSlCtwIoLwJOBesD6liDdRFtBPpf6PM0jIRcIA==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.39.0.tgz",
+      "integrity": "sha512-ssMAzKtjPV/T1IEFWNSVeaecKG3mhRHYHPMy2Ajh7V8RpOCyYBOZ48kZGyOwd25uzQX5k634tmfW27qJ/SMVQA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.32.0.tgz",
-      "integrity": "sha512-DE/UCpBF7PxznAOOlf2/Tq1aQKvqU07aaFhgGaCBd7sBn6QtBjA5SvtOvKcpr+09awdcS1AeLl2DdPGnRUZkog==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.39.0.tgz",
+      "integrity": "sha512-XvAn9I/rfVWpv9KSKLc24mYqfVHJ4o9PiwcHQb6FyJyeVvCbrHpTFN1iAaXSsBSTCs6mMVKNuZFZv7Sg7c++bg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
         "rungen": "^0.3.2"
@@ -9139,24 +11260,101 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.32.0.tgz",
-      "integrity": "sha512-aMD5dFNu2+orafsfTHuFfQbB6BT4J9a1Y6FTwz+ollr9Q8Ng8qlt79qS2rcGEBHTyxTD2SOxPVU3+DAysl6KnQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.39.0.tgz",
+      "integrity": "sha512-8ylhw36Hfn12ALKq1Ns7ZAUXPyFspX7ILHHsJtYk6S8uCp9T2ixwBDPHWT1t4g+vhBgCb316dofY0Gr3wAUFhw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/core-data": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/notices": "^5.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/url": "^4.32.0"
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/notices": "^5.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/url": "^4.39.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9168,21 +11366,21 @@
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.32.0.tgz",
-      "integrity": "sha512-CUiKYCkuoAqfyMPkw4HRcWcK8bKdOCfMiHUfZvAaapjWB6qGhSsL4MRlmQV8IGtbHj5tUVkBAzTm5V5tIV2/yQ==",
+      "version": "7.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.39.0.tgz",
+      "integrity": "sha512-4wpQyyaZ9vmInRk0oiBpPFmLtGn6w+ejrQvaCeDeOAeA+IYdEvrTMEbGp7NhYZ9llZvEqEQ8/yNcoAczE4DLSg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.32.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/escape-html": "^3.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/keycodes": "^4.32.0",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/keycodes": "^4.39.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -9194,18 +11392,81 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/router": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.32.0.tgz",
-      "integrity": "sha512-nP/YJH7cQbVOODfjTw+dwnBg6dm3GRc6KtI2rx3kAfcd/uFtE6tZs31t90HTKOAwFMsf3k0R8yItX0nes9lE0Q==",
+    "node_modules/@wordpress/route": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/route/-/route-0.5.0.tgz",
+      "integrity": "sha512-1PU7wGbkKxC3SRZGEI0TysNYtXb2WWfvFrIH7aO53GvOAVfTvaQNfrZ+SyhPpg6wDC3M1OQjjfRpNCOVVOZmvQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/url": "^4.32.0",
+        "@tanstack/history": "^1.133.28",
+        "@tanstack/react-router": "^1.120.5",
+        "@wordpress/private-apis": "^1.39.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/route/node_modules/@tanstack/react-router": {
+      "version": "1.158.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.158.1.tgz",
+      "integrity": "sha512-ZRBhs0tJDPeYGVrBhXPkGs+mOKqKKMM4OfvYSNvWIYZGfs8KQcqxPaN8OnUvKsnAGtzwusVWDpBipqVZWJd0lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.154.14",
+        "@tanstack/react-store": "^0.8.0",
+        "@tanstack/router-core": "1.158.1",
+        "isbot": "^5.1.22",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@wordpress/route/node_modules/@tanstack/react-router/node_modules/@tanstack/react-store": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.8.0.tgz",
+      "integrity": "sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.8.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@wordpress/router": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.39.0.tgz",
+      "integrity": "sha512-w5jea4jm5xml1ngcNvJlu0eNlpJW9SZTnnGCev4qoZJXFg9UM/+vcDRq++s2qDEeN1eWuxjef5IRIKlQdXeJJg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/url": "^4.39.0",
         "history": "^5.3.0",
         "route-recognizer": "^0.3.4"
       },
@@ -9218,25 +11479,25 @@
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "30.25.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.25.0.tgz",
-      "integrity": "sha512-sUL6R4aYzdvrg8V7W49RxLsLavv7ZuQ4/6gIb/ZCYZDwhzT4feqdMXyViwmlyaQMIxTMJy93zD+7jFrUGy07Sw==",
+      "version": "30.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.27.0.tgz",
+      "integrity": "sha512-gXGptazCxAaR7g8kcN5joj7B5fCm0VeBHOmnDBs2dbQ4W4F3tfzdg6CTEj8LonF9bWQXlSy3ku8EqWCdkSG9Xw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.32.0",
-        "@wordpress/browserslist-config": "^6.32.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.32.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.32.0",
-        "@wordpress/eslint-plugin": "^22.18.0",
-        "@wordpress/jest-preset-default": "^12.32.0",
-        "@wordpress/npm-package-json-lint-config": "^5.32.0",
-        "@wordpress/postcss-plugins-preset": "^5.32.0",
-        "@wordpress/prettier-config": "^4.32.0",
-        "@wordpress/stylelint-config": "^23.24.0",
+        "@wordpress/babel-preset-default": "^8.34.0",
+        "@wordpress/browserslist-config": "^6.34.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.34.0",
+        "@wordpress/e2e-test-utils-playwright": "^1.34.0",
+        "@wordpress/eslint-plugin": "^22.20.0",
+        "@wordpress/jest-preset-default": "^12.34.0",
+        "@wordpress/npm-package-json-lint-config": "^5.34.0",
+        "@wordpress/postcss-plugins-preset": "^5.34.0",
+        "@wordpress/prettier-config": "^4.34.0",
+        "@wordpress/stylelint-config": "^23.26.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "29.7.0",
         "babel-loader": "9.2.1",
@@ -9292,7 +11553,7 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "@playwright/test": "^1.55.0",
+        "@playwright/test": "^1.56.1",
         "@wordpress/env": "^10.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -9336,13 +11597,6 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/@wordpress/scripts/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/@wordpress/scripts/node_modules/doctrine": {
       "version": "3.0.0",
@@ -9506,19 +11760,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -9624,22 +11865,98 @@
       }
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.8.0.tgz",
-      "integrity": "sha512-ElHEqd4Yd7Kujp2aSv5lgrsEGSO7p8WaEFwhJSDpVxb56aVwk/WwtNtVXryFlQVXGURezmbUQSXwanN7G/HdFA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.15.0.tgz",
+      "integrity": "sha512-Ksct4OBhol+ugR+CwVyxhqeXIdiRjgZMFxap2h/LTsqyZ7ndLSFh/vCXqQhphIpM9di7ZKkkH5imItPLy3N8SA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/deprecated": "^4.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/url": "^4.32.0"
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/url": "^4.39.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9651,13 +11968,12 @@
       }
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.32.0.tgz",
-      "integrity": "sha512-z8es//Y7eMk8hDjeIo1PJ4auXZ0JN87n/CC6GD3uW5wgOvpRqiLjT5QpxCBqfKzOisUnNkYbrEjeChpgOT1gMw==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.39.0.tgz",
+      "integrity": "sha512-2aDAwkwFbheyDqdL4cqWcbByC4FgJ1c+t0hKDz4yX1KeeXlB5VYEdT2gXU9GGA4nQaQ3ZvlCFowQL3BYcarnCw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "memize": "^2.0.1"
       },
       "engines": {
@@ -9666,13 +11982,12 @@
       }
     },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.32.0.tgz",
-      "integrity": "sha512-qjXu4Dncch1UL4AUC3zJAOCj8mRy4+kAt+Rz3OoZV4vSsccUXKutxSCc12HGYS9IO+cjhj9yiWrSpGWCdMD/Sw==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.39.0.tgz",
+      "integrity": "sha512-UhQ8rzIfdWYV0uITZOWl1G1HI+9ay679Ig+9W7qcGjp8Okwl4XyMF+B7f1jtqjbAhq45spzUgPs1d3+F4aiWYA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "change-case": "^4.1.2"
       },
       "engines": {
@@ -9681,13 +11996,14 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.24.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.24.0.tgz",
-      "integrity": "sha512-qF0zRv/fLK29/jEjQnY0xy1hrP5Cv6ReG10QkVAtSlaBvu07Hu+RWNIVrSznwlrbzzP+2JM61lO2oAeX/3LD+g==",
+      "version": "23.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.31.0.tgz",
+      "integrity": "sha512-+Vy769qVrjnSqCZCMolh5dHu1np+iZKkICQoccgF/VXXjp+dYLJaDzXqbKqtGU87oirUT7Q1tqWNovbuaBowIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stylistic/stylelint-plugin": "^3.0.1",
+        "@wordpress/theme": "^0.6.0",
         "stylelint-config-recommended": "^14.0.1",
         "stylelint-config-recommended-scss": "^14.1.0"
       },
@@ -9701,21 +12017,18 @@
       }
     },
     "node_modules/@wordpress/sync": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.32.0.tgz",
-      "integrity": "sha512-yKahpmYRm1VbXvU/6M2eXiQgMWl45VCcxDgMO+Y/2Wh1C/HyVZdgsNpg5c2ikXUolyKRKd7vuSMIn+agSceHTw==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.39.0.tgz",
+      "integrity": "sha512-oYNxhMaNf2ZYOIuPmxkBgFNvqiSnnT8uTHrFgim09aN2fxA8Mu1G86EBokqHfAXBfx/NTiYOLbCy4bhGsjdbQg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@types/simple-peer": "^9.11.5",
-        "@wordpress/url": "^4.32.0",
-        "import-locals": "^2.0.0",
-        "lib0": "^0.2.42",
-        "simple-peer": "^9.11.0",
-        "y-indexeddb": "~9.0.11",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "diff": "4.0.2",
+        "fast-deep-equal": "3.1.3",
+        "lib0": "0.2.85",
         "y-protocols": "^1.0.5",
-        "y-webrtc": "~10.2.5",
         "yjs": "~13.6.6"
       },
       "engines": {
@@ -9723,29 +12036,78 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/token-list": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.32.0.tgz",
-      "integrity": "sha512-FgA06HzE0dESSXAQIgzKfLa9Z2Qv1Gv4Blcskyko7wNTcQfPq53oByvCiA0aMFh/LmKHNIa2FR1vn3Y3ck/Ewg==",
+    "node_modules/@wordpress/theme": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.6.0.tgz",
+      "integrity": "sha512-n/O1djUn+jny46JyqCwD77nPV4zCUBIn+0ICp8fDYLXpQ7FfCfCrEfhlkQkcVB45KC1iu6IMAsLOA/9hzavHoQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "colorjs.io": "^0.6.0",
+        "memize": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "stylelint": "^16.8.2"
+      },
+      "peerDependenciesMeta": {
+        "stylelint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/token-list": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.39.0.tgz",
+      "integrity": "sha512-p8lVv2wPJ76CqGnwRCeQcho6MPDlBdcdyCmAtgrIe5BGS19Tvp+EpsSkfvKrFa9JkAWtOSmAiKVqIHW/LqkujA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/undo-manager": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.32.0.tgz",
-      "integrity": "sha512-pEnsf9zvk61ijX28wmJ7HM2Xb2Dbdg80feF0QVFAsngFiS34r9/K1JE+y56OdyYY20ZGPbmbHLpIHX0ghjhpoQ==",
+    "node_modules/@wordpress/ui": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.6.0.tgz",
+      "integrity": "sha512-KV7JkQ4bvuCWZ2+82jnhzthomCIS7wO8+6cSrkhQUgeVbp0TdGCXCFHwKXfw1O/P/S6IClqpTFgInXFz/gA1DQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/is-shallow-equal": "^5.32.0"
+        "@base-ui/react": "^1.0.0",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/theme": "^0.6.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.39.0.tgz",
+      "integrity": "sha512-LcCqVZk3K6tltAuUB1gXyo7lAbS48WP/RsRLrm4GBchY+kQwUT+kme30zCrRfsEJJaYCtfcGo1POIgda/HwHpw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9753,22 +12115,21 @@
       }
     },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.17.0.tgz",
-      "integrity": "sha512-AyU/AQOIwjgWiCcI6K36up87RNXSjvIac8oqEgd/U29Srk7aD51griD43tbRB1T3xy9TMoyASiBrAgT1w33lHQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.24.0.tgz",
+      "integrity": "sha512-S8CorvG4V3FQoKZopctBwMGt8owX086FlvM84UNRFP3A5asO37sFBjaxHn4rZoOgdq99acA43bnYfzA3FtEfEA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/blob": "^4.32.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/preferences": "^4.32.0",
-        "@wordpress/private-apis": "^1.32.0",
-        "@wordpress/url": "^4.32.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/blob": "^4.39.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/preferences": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/url": "^4.39.0",
         "uuid": "^9.0.1"
       },
       "engines": {
@@ -9781,13 +12142,12 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.32.0.tgz",
-      "integrity": "sha512-B7Q6sKzBqSLUdQiW8oL69LFuky/IRrXDbBhPpOJruwV4l6eH6UhTlnY4QZYi1Ke91c/VJZRjUKx1fNWPJx5d9w==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.39.0.tgz",
+      "integrity": "sha512-pWOtqLcApB1EZnD2am/vMHxkCLgHzpysUypP8N8jz+USdLyOKy7vaY3v94+HAL1M9HBoT9VpllWEg+LxsO/eqQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "remove-accents": "^0.5.0"
       },
       "engines": {
@@ -9796,16 +12156,15 @@
       }
     },
     "node_modules/@wordpress/viewport": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.32.0.tgz",
-      "integrity": "sha512-2cPqzOH5ENHAk/p3xHE4AJU9Iw9cN2YHOFe/VqQoiJPlCzl7eM0nF4cjdSE9xBFmR7N4xot5SsKpk+JzWYw7Og==",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.39.0.tgz",
+      "integrity": "sha512-NWN/NLm30jZEyNYV3bzQGzNsTOQy2oKwXIuvSr9jZ8inEsGjzZ+CPIHOwmZSk3WSvp3JhBHFJZk+qOAacJfAzQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/element": "^6.32.0"
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/element": "^6.39.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9816,9 +12175,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.32.0.tgz",
-      "integrity": "sha512-6dPNKfJAOXijIMi9k/QdS/IQvHXcl5ErNM10y5dIhhLDuGmsZlQER06VrVmQIVAkbsmL49OfrqkqMOQidp61JA==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.39.0.tgz",
+      "integrity": "sha512-NV2WoU4XxTqZU/3k2D5m5cHIw/uM2dlDgW5u1U5fmFIYLGg43WWMlSHQEu6F4tm7fqFt7k4qwT/FymucqHYp7Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -9827,24 +12186,24 @@
       }
     },
     "node_modules/@wordpress/widgets": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.32.0.tgz",
-      "integrity": "sha512-8flv3T18TYf20kEXvGNVzqU+p+rC3KJXdutw9u7gANjc1hXLe3OOKA7xAKqYjoHhnYzDA8Pi3/XYG8Qx3LpGcA==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.39.0.tgz",
+      "integrity": "sha512-LsigkzqQ+KljOoIOplEfeIVbbrlbqv0EOE+Pv/4SIaowXOz2gLOzol5QWDVMm0z4PRj73y257sTwmbg96kPaMA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.32.0",
-        "@wordpress/block-editor": "^15.5.0",
-        "@wordpress/blocks": "^15.5.0",
-        "@wordpress/components": "^30.5.0",
-        "@wordpress/compose": "^7.32.0",
-        "@wordpress/core-data": "^7.32.0",
-        "@wordpress/data": "^10.32.0",
-        "@wordpress/element": "^6.32.0",
-        "@wordpress/i18n": "^6.5.0",
-        "@wordpress/icons": "^10.32.0",
-        "@wordpress/notices": "^5.32.0",
+        "@wordpress/api-fetch": "^7.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/block-editor": "^15.12.0",
+        "@wordpress/blocks": "^15.12.0",
+        "@wordpress/components": "^32.1.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/core-data": "^7.39.0",
+        "@wordpress/data": "^10.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/notices": "^5.39.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -9856,15 +12215,89 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/wordcount": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.32.0.tgz",
-      "integrity": "sha512-bVxNPejXkKo7s2HE2kkN5K1WqnkFp9yGRe40MNuq9/iLS0hXKqjMo3Ae0Gq2LQLbgVC/VSDXqB8B+vjFRZt3CQ==",
+    "node_modules/@wordpress/widgets/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/widgets/node_modules/@wordpress/components": {
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+      "integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@ariakit/react": "^0.4.15",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.39.0",
+        "@wordpress/base-styles": "^6.15.0",
+        "@wordpress/compose": "^7.39.0",
+        "@wordpress/date": "^5.39.0",
+        "@wordpress/deprecated": "^4.39.0",
+        "@wordpress/dom": "^4.39.0",
+        "@wordpress/element": "^6.39.0",
+        "@wordpress/escape-html": "^3.39.0",
+        "@wordpress/hooks": "^4.39.0",
+        "@wordpress/html-entities": "^4.39.0",
+        "@wordpress/i18n": "^6.12.0",
+        "@wordpress/icons": "^11.6.0",
+        "@wordpress/is-shallow-equal": "^5.39.0",
+        "@wordpress/keycodes": "^4.39.0",
+        "@wordpress/primitives": "^4.39.0",
+        "@wordpress/private-apis": "^1.39.0",
+        "@wordpress/rich-text": "^7.39.0",
+        "@wordpress/warning": "^3.39.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/wordcount": {
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.39.0.tgz",
+      "integrity": "sha512-W8lY9zNeIL+afa7KvOwwFeA62IsJBhPJBmf71hPpInXBx+zBUlzFd8lTXiLbxCNLX665ABfrjs47RS1l7ZZLlQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -9935,6 +12368,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -10077,6 +12523,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
+      }
+    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -10148,21 +12607,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/argparse/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
@@ -10429,19 +12878,20 @@
       "dev": true
     },
     "node_modules/atomically": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
-      "integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
+      "integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "stubborn-fs": "^1.2.5",
-        "when-exit": "^2.1.1"
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "version": "10.4.24",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
+      "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
       "dev": true,
       "funding": [
         {
@@ -10459,10 +12909,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001766",
+        "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -10499,9 +12948,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -10509,14 +12958,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -10888,6 +13337,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/basic-ftp": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
@@ -10923,36 +13382,28 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/body-parser/node_modules/debug": {
@@ -10960,6 +13411,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10969,6 +13421,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -10980,7 +13433,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bonjour-service": {
       "version": "1.2.1",
@@ -11023,9 +13477,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -11043,10 +13497,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -11063,31 +13518,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -11120,33 +13550,33 @@
       }
     },
     "node_modules/bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/cacheable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.0.tgz",
-      "integrity": "sha512-zzL1BxdnqwD69JRT0dihnawAcLkBMwAH+hZSKjUzeBbPedVhk3qYPjRw9VOMYWwt5xRih5xd8S+3kEdGohZm/g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
+      "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memoize": "^2.0.3",
-        "@cacheable/memory": "^2.0.3",
-        "@cacheable/utils": "^2.1.0",
-        "hookified": "^1.12.1",
-        "keyv": "^5.5.3",
-        "qified": "^0.5.0"
+        "@cacheable/memory": "^2.0.7",
+        "@cacheable/utils": "^2.3.3",
+        "hookified": "^1.15.0",
+        "keyv": "^5.5.5",
+        "qified": "^0.6.0"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-      "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11275,9 +13705,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001722",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
-      "integrity": "sha512-DCQHBBZtiK6JVkAGw7drvAMK0Q0POD/xZvEmDp6baiMMP6QXXk9HpD6mNYBZWhOPG6LvIDb82ITqtWjhDckHCA==",
+      "version": "1.0.30001769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
       "dev": true,
       "funding": [
         {
@@ -11586,9 +14016,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11621,6 +14051,17 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+      "integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/color"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -11673,17 +14114,18 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
         "debug": "2.6.9",
-        "on-headers": "~1.0.2",
-        "safe-buffer": "5.1.2",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
       "engines": {
@@ -11705,11 +14147,15 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/compression/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.20",
@@ -11786,6 +14232,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11795,6 +14242,23 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
+      "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
@@ -11924,9 +14388,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
-      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -11990,24 +14454,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/create-jest": {
@@ -12331,10 +14777,11 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cwd": {
       "version": "0.10.0",
@@ -12520,9 +14967,9 @@
       "dev": true
     },
     "node_modules/dedent": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
+      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -12652,8 +15099,19 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -12661,6 +15119,7 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -12711,10 +15170,11 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -12821,10 +15281,11 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -12922,12 +15383,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.166",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
-      "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
     },
@@ -12961,10 +15423,11 @@
       }
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -12990,14 +15453,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -13057,13 +15520,6 @@
       "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
       "dev": true
     },
-    "node_modules/err-code": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -13083,9 +15539,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13171,27 +15627,27 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
+        "es-abstract": "^1.24.1",
         "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.0.3",
+        "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.6",
+        "get-intrinsic": "^1.3.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.2.0",
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.4",
+        "iterator.prototype": "^1.1.5",
         "safe-array-concat": "^1.1.3"
       },
       "engines": {
@@ -13398,6 +15854,31 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -13418,6 +15899,41 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils": {
@@ -13517,9 +16033,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13560,14 +16076,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.11.7"
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.12"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -13795,6 +16311,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -13883,54 +16400,50 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -13949,10 +16462,11 @@
       "dev": true
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "dev": true
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -14183,17 +16697,18 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.2",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -14205,6 +16720,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -14213,7 +16729,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-cache-dir": {
       "version": "4.0.0",
@@ -14494,13 +17011,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -14524,16 +17044,16 @@
       "license": "MIT"
     },
     "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
+        "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
     },
@@ -14570,6 +17090,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -14585,10 +17106,11 @@
       }
     },
     "node_modules/fs-monkey": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
-      "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
+      "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -14668,13 +17190,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/get-browser-rtc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
-      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -14797,6 +17312,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -15117,6 +17645,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
+      "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -15185,9 +17726,9 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.1.tgz",
-      "integrity": "sha512-xnKGl+iMIlhrZmGHB729MqlmPoWBznctSQTYCpFKqNsCgimJQmithcW0xSQMMFzYnV2iKUh25alswn6epgxS0Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "dev": true,
       "license": "MIT"
     },
@@ -15278,6 +17819,17 @@
       "integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
       "dev": true
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.2.tgz",
+      "integrity": "sha512-9nD3Rj3/FuQt83AgIa1Y3ruzspwFFA54AJbQnohXN+K6fL1/bhcDQJJY5Ne4L4A163ADQFVESd/0TLyNoV0mfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.0.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -15312,6 +17864,28 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/html-react-parser": {
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.11.tgz",
+      "integrity": "sha512-WnSQVn/D1UTj64nSz5y8MriL+MrbsZH80Ytr1oqKqs8DGZnphWY1R1pl3t7TY3rpqTSu+FHA21P80lrsmrdNBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.2",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.21"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -15325,6 +17899,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -15332,19 +17939,24 @@
       "dev": true
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-link-header": {
@@ -15392,10 +18004,11 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -15574,13 +18187,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-locals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-locals/-/import-locals-2.0.0.tgz",
-      "integrity": "sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -15623,6 +18229,13 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -15803,6 +18416,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/is-callable": {
@@ -16265,6 +18901,16 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isbot": {
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.34.tgz",
+      "integrity": "sha512-aCMIBSKd/XPRYdiCQTLC8QHH4YT8B3JUADu+7COgYIZPvkeoMcUHMRjZLM9/7V8fCj+l7FSREc1lOPNjzogo/A==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -16919,9 +19565,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -17056,14 +19702,13 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -17330,16 +19975,15 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
-      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "version": "0.2.85",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.85.tgz",
+      "integrity": "sha512-vtAhVttLXCu3ps2OIsTz8CdKYKdcMo7ds1MNBIcSXz6vrY8sxASqpTi4vmsAIn7xjWvyT7haKcWW6woP6jebjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
       "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
         "0gentesthtml": "bin/gentesthtml.js",
         "0serve": "bin/0serve.js"
       },
@@ -17414,9 +20058,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.12.tgz",
-      "integrity": "sha512-mP9iLFZwH+FapKJLeA7/fLqOlSUwYpMwjR1P5J23qd4e7qGJwecJccJqHYrjw33jmIZYV4dtiTHPD/J+1e7cEw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.0.tgz",
+      "integrity": "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17436,28 +20080,28 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core": {
-      "version": "24.25.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.25.0.tgz",
-      "integrity": "sha512-8Xs6q3Ut+C8y7sAaqjIhzv1QykGWG4gc2mEZ2mYE7siZFuRp4xQVehOf8uQKSQAkeL7jXUs3mknEeiqnRqUKvQ==",
+      "version": "24.37.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.2.tgz",
+      "integrity": "sha512-nN8qwE3TGF2vA/+xemPxbesntTuqD9vCGOiZL2uh8HES3pPzLX20MyQjB42dH2rhQ3W3TljZ4ZaKZ0yX/abQuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.12",
-        "chromium-bidi": "9.1.0",
+        "@puppeteer/browsers": "2.12.0",
+        "chromium-bidi": "13.1.1",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1508733",
+        "devtools-protocol": "0.0.1566079",
         "typed-query-selector": "^2.12.0",
-        "webdriver-bidi-protocol": "0.3.7",
-        "ws": "^8.18.3"
+        "webdriver-bidi-protocol": "0.4.0",
+        "ws": "^8.19.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-9.1.0.tgz",
-      "integrity": "sha512-rlUzQ4WzIAWdIbY/viPShhZU2n21CxDUgazXVbw4Hu1MwaeUSEksSeM6DqPgpRjCLXRk702AVRxJxoOz0dw4OA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.1.tgz",
+      "integrity": "sha512-zB9MpoPd7VJwjowQqiW3FKOvQwffFMjQ8Iejp5ZW+sJaKLRhZX1sTxzl3Zt22TDB4zP0OOqs8lRoY7eAW5geyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17469,16 +20113,16 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1508733",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
-      "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
+      "version": "0.0.1566079",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+      "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17498,9 +20142,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -17589,12 +20233,17 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -17627,16 +20276,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "dev": true,
       "license": "MIT"
     },
@@ -17758,9 +20407,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -17815,12 +20464,6 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -17866,12 +20509,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/markdownlint-cli/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/markdownlint-cli/node_modules/commander": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
@@ -17888,18 +20525,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/markdownlint-cli/node_modules/minimatch": {
@@ -17965,6 +20590,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -17974,6 +20600,7 @@
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
       "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "fs-monkey": "^1.0.4"
       },
@@ -18052,10 +20679,14 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -18427,6 +21058,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -18478,10 +21125,11 @@
       "optional": true
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -18494,9 +21142,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -18517,9 +21165,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -18534,16 +21182,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18611,9 +21249,9 @@
       "license": "MIT"
     },
     "node_modules/npm-package-json-lint/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -18823,6 +21461,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -18831,10 +21470,11 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -19197,10 +21837,11 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-      "dev": true
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -19229,9 +21870,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
       "dev": true,
       "license": "MIT"
     },
@@ -19276,6 +21917,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pirates": {
@@ -19353,13 +22004,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
-      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.0"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -19372,9 +22023,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
-      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -19550,6 +22201,24 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+      "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-loader": {
@@ -20112,9 +22781,9 @@
       }
     },
     "node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20145,9 +22814,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.27.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "version": "10.28.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+      "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -20182,9 +22851,9 @@
       }
     },
     "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20433,25 +23102,26 @@
       "license": "MIT"
     },
     "node_modules/qified": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.0.tgz",
-      "integrity": "sha512-Zj6Q/Vc/SQ+Fzc87N90jJUzBzxD7MVQ2ZvGyMmYtnl2u1a07CejAhvtk4ZwASos+SiHKCAIylyGHJKIek75QBw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.12.1"
+        "hookified": "^1.14.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -20510,30 +23180,23 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -20543,6 +23206,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -20667,6 +23331,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -20677,9 +23348,9 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20746,6 +23417,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
       }
     },
     "node_modules/read-pkg": {
@@ -20990,12 +23671,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -21142,6 +23817,13 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -21201,6 +23883,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve.exports": {
@@ -21581,24 +24273,25 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -21609,6 +24302,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -21617,13 +24311,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -21649,6 +24345,29 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
+      "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz",
+      "integrity": "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
       }
     },
     "node_modules/serve-index": {
@@ -21730,15 +24449,16 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -21803,7 +24523,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shallow-clone": {
       "version": "0.1.2",
@@ -22187,36 +24908,6 @@
       "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "dev": true
     },
-    "node_modules/simple-peer": {
-      "version": "9.11.1",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
-      "integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "debug": "^4.3.2",
-        "err-code": "^3.0.1",
-        "get-browser-rtc": "^1.1.0",
-        "queue-microtask": "^1.2.3",
-        "randombytes": "^2.1.0",
-        "readable-stream": "^3.6.0"
-      }
-    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -22532,6 +25223,16 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -22560,10 +25261,11 @@
       "dev": true
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -22833,10 +25535,21 @@
       }
     },
     "node_modules/stubborn-fs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
-      "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-search": {
       "version": "0.1.0",
@@ -22844,6 +25557,26 @@
       "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/stylehacks": {
       "version": "6.1.0",
@@ -22862,9 +25595,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.25.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.25.0.tgz",
-      "integrity": "sha512-Li0avYWV4nfv1zPbdnxLYBGq4z8DVZxbRgx4Kn6V+Uftz1rMoF1qiEI3oL4kgWqyYgCgs7gT5maHNZ82Gk03vQ==",
+      "version": "16.26.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+      "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
       "dev": true,
       "funding": [
         {
@@ -22879,6 +25612,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
         "@csstools/css-tokenizer": "^3.0.4",
         "@csstools/media-query-list-parser": "^4.0.3",
         "@csstools/selector-specificity": "^5.0.0",
@@ -22891,7 +25625,7 @@
         "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.1.4",
+        "file-entry-cache": "^11.1.1",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -22972,26 +25706,26 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
-      "integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
+      "integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.36.0",
-        "mdn-data": "^2.21.0",
+        "known-css-properties": "^0.37.0",
+        "mdn-data": "^2.25.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.6",
-        "postcss-selector-parser": "^7.1.0",
+        "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.0.2"
+        "stylelint": "^16.8.2"
       }
     },
     "node_modules/stylelint-scss/node_modules/css-tree": {
@@ -23015,24 +25749,17 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/stylelint-scss/node_modules/known-css-properties": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-      "integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.24.0.tgz",
-      "integrity": "sha512-i97fklrJl03tL1tdRVw0ZfLLvuDsdb6wxL+TrJ+PKkCbLrp2PCu2+OYdCKychIUm19nSM/35S6qz7pJpnXttoA==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.0.tgz",
+      "integrity": "sha512-/pUmP9UebM48q5BTqZd0yPnDjyRGhITbKh8cwa6/ZwjuDu8xq+VzmugLF7QNxpdaqqNH3J5nnv3yc8oARv096A==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23090,13 +25817,6 @@
         "postcss-selector-parser": "^7.0.0"
       }
     },
-    "node_modules/stylelint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
@@ -23146,25 +25866,25 @@
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
-      "integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.13"
+        "flat-cache": "^6.1.20"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.18.tgz",
-      "integrity": "sha512-JUPnFgHMuAVmLmoH9/zoZ6RHOt5n9NlUw/sDXsTbROJ2SFoS2DS4s+swAV6UTeTbGH/CAsZIE6M8TaG/3jVxgQ==",
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+      "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^2.1.0",
+        "cacheable": "^2.3.2",
         "flatted": "^3.3.3",
-        "hookified": "^1.12.0"
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/stylelint/node_modules/global-modules": {
@@ -23205,19 +25925,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/stylelint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/stylelint/node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -23249,9 +25956,9 @@
       }
     },
     "node_modules/stylelint/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23402,9 +26109,9 @@
       "dev": true
     },
     "node_modules/synckit": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23416,6 +26123,13 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/table": {
       "version": "6.9.0",
@@ -23469,12 +26183,17 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar-fs": {
@@ -23504,6 +26223,16 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/temml": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.10.34.tgz",
+      "integrity": "sha512-f3b5CaPwPvMviA+CtHy0qoIGWvzpRrNpXmGRc/Y1jc9gAYy+xOlndJFyn7Vfcz7cBcS8QRvv8z0EEH59sHCQxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.13.0"
+      }
+    },
     "node_modules/terser": {
       "version": "5.42.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.42.0.tgz",
@@ -23524,9 +26253,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23731,21 +26460,83 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tldts-core": {
-      "version": "7.0.17",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
-      "integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
-      "version": "7.0.17",
-      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.17.tgz",
-      "integrity": "sha512-up4oFDoumyz2RscRxoYRxf+2OvIKUHjh7rUvuGWI0PZ/47k35sadoi2JyKR0AIfTw09qcfix8bUxXFQhY1QZIQ==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.22.tgz",
+      "integrity": "sha512-Wb5HEhrSy+zJtdJ6gop7ZNQ/Iacz/0c8t+6Kp1QoT84VRfc0TfPJLrb8f6YuRvCUOVjU889KJlPcG+5glVX8GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.17"
+        "tldts-core": "^7.0.22"
       }
     },
     "node_modules/tmpl": {
@@ -23773,6 +26564,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -23972,6 +26764,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -24141,10 +26934,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -24204,14 +26998,50 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -24372,9 +27202,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -24515,9 +27345,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24545,9 +27375,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.7.tgz",
-      "integrity": "sha512-wIx5Gu/LLTeexxilpk8WxU2cpGAKlfbWRO5h+my6EMD1k5PYqM1qQO1MHUFf4f3KRnhBvpbZU7VkizAgeSEf7g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
+      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -24561,36 +27391,37 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.99.9",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-      "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+      "version": "5.105.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.6",
+        "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.14.0",
-        "browserslist": "^4.24.0",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -24645,10 +27476,11 @@
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -24720,10 +27552,11 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.10",
         "memfs": "^3.4.3",
@@ -24743,15 +27576,16 @@
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -24763,6 +27597,7 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -24774,13 +27609,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -24788,7 +27625,7 @@
         "ajv-keywords": "^5.1.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -24796,10 +27633,11 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
-      "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+      "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -24829,7 +27667,7 @@
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^5.3.1",
+        "webpack-dev-middleware": "^5.3.4",
         "ws": "^8.13.0"
       },
       "bin": {
@@ -25004,10 +27842,11 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
@@ -25042,6 +27881,13 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/webpack/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webpack/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -25050,9 +27896,9 @@
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25127,9 +27973,9 @@
       }
     },
     "node_modules/when-exit": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.4.tgz",
-      "integrity": "sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
       "dev": true,
       "license": "MIT"
     },
@@ -25223,9 +28069,9 @@
       "dev": true
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25358,31 +28204,10 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/y-indexeddb": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
-      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.74"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "peerDependencies": {
-        "yjs": "^13.0.0"
-      }
-    },
     "node_modules/y-protocols": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
-      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25398,34 +28223,6 @@
       },
       "peerDependencies": {
         "yjs": "^13.0.0"
-      }
-    },
-    "node_modules/y-webrtc": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.2.6.tgz",
-      "integrity": "sha512-1kZ4YYwksFZi8+l8mTebVX9vW6Q5MnqxMkvNU700X5dBE38usurt/JgeXSIQRpK3NwUYYb9y63Jn9FMpMH6/vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.42",
-        "simple-peer": "^9.11.0",
-        "y-protocols": "^1.0.6"
-      },
-      "bin": {
-        "y-webrtc-signaling": "bin/server.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "optionalDependencies": {
-        "ws": "^8.14.2"
-      },
-      "peerDependencies": {
-        "yjs": "^13.6.8"
       }
     },
     "node_modules/y18n": {
@@ -25494,9 +28291,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.27",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
-      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "version": "13.6.29",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
+      "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25505,6 +28302,28 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/yjs/node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "url": "https://github.com/mikethicke/wp-museum/issues"
   },
   "homepage": "https://github.com/mikethicke/wp-museum#readme",
+  "overrides": {
+    "@babel/runtime": "^7.26.10",
+    "diff": "^4.0.4"
+  },
   "devDependencies": {
     "@playwright/test": "^1.56.0",
     "@prettier/plugin-php": "^0.24.0",

--- a/release.sh
+++ b/release.sh
@@ -1,86 +1,317 @@
 #!/bin/bash
-VERSION_NUMBER=$(sed -n "s/\* Version: \(.*\)$/\1/p" ./wp-museum.php | tr -d '[:space:]')
+set -euo pipefail
+
+# ============================================================================
+# release.sh — Automate version bump, build, package, and GitHub release
+# ============================================================================
+
+PLUGIN_FILE="./wp-museum.php"
 BASE_RELEASE_DIR="./release"
 SUB_RELEASE_DIR="wp-museum"
 RELEASE_DIR="${BASE_RELEASE_DIR}/${SUB_RELEASE_DIR}"
 RELEASE_FILE="${SUB_RELEASE_DIR}.zip"
-SRC_DIR="./src"
 BLOCKS_BUILD_DIR="./build"
-REACT_DIR="${BASE_RELEASE_DIR}/${SUB_RELEASE_DIR}/react"
+REACT_DIR="${RELEASE_DIR}/react"
 
-echo "Building version ${VERSION_NUMBER} for release..."
-echo "Release directory: ${RELEASE_DIR}"
-echo "Release file: ${RELEASE_FILE}"
+# --- Defaults ---------------------------------------------------------------
+BUMP_TYPE=""
+DRY_RUN=false
+SKIP_BUILD=false
+ALLOW_BRANCH=false
 
-if [ ! -d $BASE_RELEASE_DIR ]
-then
-	mkdir $BASE_RELEASE_DIR
-	if [ ! -d $BASE_RELEASE_DIR ]
-	then
-		echo "Release directory (${BASE_RELEASE_DIR} does not exist. Exiting."
-		exit 2
+# ============================================================================
+# Helpers
+# ============================================================================
+
+usage() {
+	cat <<-'USAGE'
+	Usage: ./release.sh --major | --minor | --patch [OPTIONS]
+
+	Version bump (exactly one required):
+	  --major         Bump major version (0.7.5 -> 1.0.0)
+	  --minor         Bump minor version (0.7.5 -> 0.8.0)
+	  --patch         Bump patch version (0.7.5 -> 0.7.6)
+
+	Options:
+	  --dry-run       Preview version, release notes, and commands without executing
+	  --skip-build    Skip npm build step (reuse existing build/ directory)
+	  --allow-branch  Allow release from a non-main branch
+	  --help          Show usage
+	USAGE
+}
+
+die() {
+	echo "Error: $*" >&2
+	exit 1
+}
+
+info() {
+	echo "==> $*"
+}
+
+# Read the current version from wp-museum.php header
+read_version() {
+	sed -n 's/^[[:space:]]*\* Version:[[:space:]]*\(.*\)$/\1/p' "$PLUGIN_FILE" | tr -d '[:space:]'
+}
+
+# Compute the next version given current version and bump type
+compute_new_version() {
+	local current="$1" bump="$2"
+	local major minor patch
+	IFS='.' read -r major minor patch <<< "$current"
+
+	case "$bump" in
+		major) echo "$((major + 1)).0.0" ;;
+		minor) echo "${major}.$((minor + 1)).0" ;;
+		patch) echo "${major}.${minor}.$((patch + 1))" ;;
+	esac
+}
+
+# Get the previous tag (most recent tag reachable from HEAD)
+get_previous_tag() {
+	git describe --tags --abbrev=0 2>/dev/null || echo ""
+}
+
+# Generate release notes from git log between two refs
+generate_release_notes() {
+	local prev_tag="$1" new_tag="$2"
+	local log_range notes
+
+	if [ -n "$prev_tag" ]; then
+		log_range="${prev_tag}..HEAD"
+	else
+		log_range="HEAD"
+	fi
+
+	# Get commits, filtering out version bump and merge commits
+	notes=$(git log --format="- %s" "$log_range" \
+		| grep -v -E "^- (Version bump to|Merge (branch|pull request))" \
+		|| true)
+
+	if [ -z "$notes" ]; then
+		notes="- Maintenance release"
+	fi
+
+	echo "$notes"
+
+	if [ -n "$prev_tag" ]; then
+		echo ""
+		echo "**Full Changelog**: https://github.com/Epistemic-Technology/wp-museum/compare/${prev_tag}...${new_tag}"
+	fi
+}
+
+# ============================================================================
+# Argument parsing
+# ============================================================================
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--major)      BUMP_TYPE="major" ;;
+		--minor)      BUMP_TYPE="minor" ;;
+		--patch)      BUMP_TYPE="patch" ;;
+		--dry-run)    DRY_RUN=true ;;
+		--skip-build) SKIP_BUILD=true ;;
+		--allow-branch) ALLOW_BRANCH=true ;;
+		--help)       usage; exit 0 ;;
+		*)            die "Unknown option: $1. Use --help for usage." ;;
+	esac
+	shift
+done
+
+if [ -z "$BUMP_TYPE" ]; then
+	usage
+	die "Exactly one of --major, --minor, or --patch is required."
+fi
+
+# ============================================================================
+# Pre-flight checks
+# ============================================================================
+
+info "Running pre-flight checks..."
+
+# Branch check
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ] && [ "$ALLOW_BRANCH" = false ]; then
+	die "Must be on 'main' branch (currently on '${CURRENT_BRANCH}'). Use --allow-branch to override."
+fi
+
+# Clean working tree
+if [ -n "$(git status --porcelain)" ]; then
+	die "Working tree is not clean. Commit or stash changes before releasing."
+fi
+
+# Required tools
+for tool in npm gh git zip; do
+	if ! command -v "$tool" &>/dev/null; then
+		die "Required tool '$tool' not found in PATH."
+	fi
+done
+
+# GitHub CLI auth
+if ! gh auth status &>/dev/null; then
+	die "'gh auth status' failed. Please authenticate with: gh auth login"
+fi
+
+# Read current version and compute new version
+CURRENT_VERSION=$(read_version)
+if [ -z "$CURRENT_VERSION" ]; then
+	die "Could not read current version from ${PLUGIN_FILE}."
+fi
+
+NEW_VERSION=$(compute_new_version "$CURRENT_VERSION" "$BUMP_TYPE")
+NEW_TAG="v${NEW_VERSION}"
+
+# Check tag doesn't already exist
+if git rev-parse "$NEW_TAG" &>/dev/null; then
+	die "Tag '${NEW_TAG}' already exists."
+fi
+
+PREV_TAG=$(get_previous_tag)
+
+info "Current version: ${CURRENT_VERSION}"
+info "New version:     ${NEW_VERSION} (${BUMP_TYPE} bump)"
+info "New tag:         ${NEW_TAG}"
+info "Previous tag:    ${PREV_TAG:-<none>}"
+
+# ============================================================================
+# Dry-run mode
+# ============================================================================
+
+if [ "$DRY_RUN" = true ]; then
+	echo ""
+	echo "========== DRY RUN =========="
+	echo ""
+	echo "Release notes preview:"
+	echo "---"
+	generate_release_notes "$PREV_TAG" "$NEW_TAG"
+	echo "---"
+	echo ""
+	echo "Commands that would execute:"
+	echo "  1. sed -i '' 's/\\* Version: ${CURRENT_VERSION}/* Version: ${NEW_VERSION}/' ${PLUGIN_FILE}"
+	echo "  2. git add ${PLUGIN_FILE} && git commit -m \"Version bump to ${NEW_VERSION}\""
+	if [ "$SKIP_BUILD" = false ]; then
+		echo "  3. rm -rf ${BLOCKS_BUILD_DIR} && npm run build"
+	else
+		echo "  3. (skipped) npm run build"
+	fi
+	echo "  4. Create ${BASE_RELEASE_DIR}/${RELEASE_FILE} with packaged plugin"
+	echo "  5. git tag -a ${NEW_TAG} -m \"Release ${NEW_TAG}\""
+	echo "  6. git push origin ${CURRENT_BRANCH} && git push origin --tags"
+	echo "  7. gh release create ${NEW_TAG} ${BASE_RELEASE_DIR}/${RELEASE_FILE} --title \"${NEW_TAG}\" --draft"
+	echo ""
+	echo "No changes were made."
+	exit 0
+fi
+
+# ============================================================================
+# Step 1: Version bump
+# ============================================================================
+
+info "Bumping version in ${PLUGIN_FILE}..."
+sed -i '' "s/\\* Version: ${CURRENT_VERSION}/* Version: ${NEW_VERSION}/" "$PLUGIN_FILE"
+
+# Verify the change
+UPDATED_VERSION=$(read_version)
+if [ "$UPDATED_VERSION" != "$NEW_VERSION" ]; then
+	die "Version update failed. Expected '${NEW_VERSION}', got '${UPDATED_VERSION}'."
+fi
+
+git add "$PLUGIN_FILE"
+git commit -m "Version bump to ${NEW_VERSION}"
+info "Committed version bump."
+
+# ============================================================================
+# Step 2: Build
+# ============================================================================
+
+if [ "$SKIP_BUILD" = false ]; then
+	info "Building assets..."
+	rm -rf "$BLOCKS_BUILD_DIR"
+	npm run build
+
+	if [ ! -d "$BLOCKS_BUILD_DIR" ] || [ -z "$(ls -A "$BLOCKS_BUILD_DIR")" ]; then
+		die "Build failed — ${BLOCKS_BUILD_DIR} is empty or missing."
+	fi
+	info "Build complete."
+else
+	info "Skipping build (--skip-build)."
+	if [ ! -d "$BLOCKS_BUILD_DIR" ] || [ -z "$(ls -A "$BLOCKS_BUILD_DIR")" ]; then
+		die "Build directory ${BLOCKS_BUILD_DIR} is empty or missing. Remove --skip-build to rebuild."
 	fi
 fi
 
-if [ ! -d $RELEASE_DIR ]
-then
-	mkdir $RELEASE_DIR
-	if [ ! -d $RELEASE_DIR ]
-	then
-		echo "Failed to create ${RELEASE_DIR}. Exiting"
-		exit 2
-	fi
-fi
+# ============================================================================
+# Step 3: Package
+# ============================================================================
 
-if [ ! -d $REACT_DIR ]
-then
-	mkdir $REACT_DIR
-	if [ ! -d $REACT_DIR ]
-	then
-		echo "Failed to create ${REACT_DIR}. Exiting"
-		exit 2
-	fi
-fi
+info "Packaging release..."
 
-if [ ! -d $BLOCKS_BUILD_DIR ]
-then
-	echo "Blocks build directory (${BLOCKS_BUILD_DIR}) does not exist. Exiting."
-	rmdir $RELEASE_DIR
-	exit 2
-fi
+# Clean and create release directories
+rm -rf "$RELEASE_DIR"
+mkdir -p "$RELEASE_DIR" "$REACT_DIR"
 
-rm -rf $BLOCKS_BUILD_DIR
-echo "Building blocks..."
-npm run build
-if [ ! "$(ls -A ${BLOCKS_BUILD_DIR})" ]
-then
-	echo "Blocks failed to build. Exiting."
-	rmdir $RELEASE_DIR
-	exit 2
-fi
+# Copy files
+cp "$PLUGIN_FILE" "$RELEASE_DIR/"
+cp -r "$BLOCKS_BUILD_DIR"/* "$REACT_DIR/"
+cp -r ./src/* "$RELEASE_DIR/"
 
-echo "Copying files to release directory..."
-cp ./wp-museum.php $RELEASE_DIR
-cp -r ./build/* $REACT_DIR
-cp -r ./src/* $RELEASE_DIR
+# Patch DEV_BUILD to false in the release copy
+sed -i '' 's/const DEV_BUILD = true/const DEV_BUILD = false/' "$RELEASE_DIR/wp-museum.php"
 
-echo "Setting DEV_BUILD to false..."
-sed -i '' 's/const DEV_BUILD = true/const DEV_BUILD = false/' $RELEASE_DIR/wp-museum.php
-
-echo "Creating release .zip file."
-cd $BASE_RELEASE_DIR
-zip -r $RELEASE_FILE $SUB_RELEASE_DIR
+# Create zip
+cd "$BASE_RELEASE_DIR"
+zip -r "$RELEASE_FILE" "$SUB_RELEASE_DIR"
 cd ..
-echo "Created ${BASE_RELEASE_DIR}/${RELEASE_FILE}"
 
-echo "Tagging release..."
-git tag -a ${VERSION_NUMBER} -m "Release ${VERSION_NUMBER}"
+info "Created ${BASE_RELEASE_DIR}/${RELEASE_FILE}"
+
+# ============================================================================
+# Step 4: Tag and push
+# ============================================================================
+
+info "Tagging ${NEW_TAG}..."
+git tag -a "$NEW_TAG" -m "Release ${NEW_TAG}"
+
+info "Pushing to origin..."
+git push origin "$CURRENT_BRANCH"
 git push origin --tags
 
-read -p 'Delete release directory (y/n)? ' yn
-if [ $yn = 'y' ] || [ $yn = 'Y' ]
-then
-	rm -r ${RELEASE_DIR}
-fi
+# ============================================================================
+# Step 5: GitHub release
+# ============================================================================
 
-echo "Done."
+info "Creating GitHub draft release..."
+
+RELEASE_NOTES=$(generate_release_notes "$PREV_TAG" "$NEW_TAG")
+
+gh release create "$NEW_TAG" \
+	"${BASE_RELEASE_DIR}/${RELEASE_FILE}" \
+	--title "$NEW_TAG" \
+	--notes "$RELEASE_NOTES" \
+	--draft
+
+RELEASE_URL=$(gh release view "$NEW_TAG" --json url --jq '.url')
+
+# ============================================================================
+# Step 6: Cleanup
+# ============================================================================
+
+info "Cleaning up release directory..."
+rm -rf "$RELEASE_DIR"
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo "============================================"
+echo "  Release ${NEW_TAG} created successfully!"
+echo "============================================"
+echo ""
+echo "  Version:       ${NEW_VERSION}"
+echo "  Tag:           ${NEW_TAG}"
+echo "  Zip:           ${BASE_RELEASE_DIR}/${RELEASE_FILE}"
+echo "  Draft release: ${RELEASE_URL}"
+echo ""
+echo "  Review the draft release on GitHub and publish when ready."
+echo ""


### PR DESCRIPTION
## Summary
- Update npm dependencies to resolve 48 Dependabot security vulnerabilities (bumps to webpack, postcss, nanoid, etc.)
- Rewrite `release.sh` with automated version bumping (`--major`/`--minor`/`--patch`), build, packaging, and draft GitHub release creation via `gh` CLI
- New release script includes pre-flight checks, `--dry-run` mode, and non-interactive execution

## Test plan
- [x] Run `./release.sh --help` to verify usage output
- [x] Run `./release.sh --patch --dry-run` on `main` to preview a patch release
- [x] Verify `npm run build` still succeeds with updated dependencies
- [ ] (Optional) Test a real release on a test branch with `--allow-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)