### PR TITLE
Add "links" field type for mixed internal/external link lists (#115)

### DIFF
--- a/src/actions-filters.php
+++ b/src/actions-filters.php
@@ -184,6 +184,14 @@ add_filter( 'posts_where', __NAMESPACE__ . '\post_search_filter', 10, 2 );
  */
 add_filter( 'query_vars', __NAMESPACE__ . '\add_title_content_query_vars' );
 
+/**
+ * Extend search to also match catalogue ID fields on museum objects so
+ * LinkControl and core's /wp/v2/search find objects by ID, not just title.
+ *
+ * @see object-functions.php::extend_object_search_to_cat_fields()
+ */
+add_filter( 'posts_search', __NAMESPACE__ . '\extend_object_search_to_cat_fields', 10, 2 );
+
 add_filter(
 	'posts_results',
 	__NAMESPACE__ . '\add_object_results_to_main_search_query',

--- a/src/admin-react/src/objects/field-edit.js
+++ b/src/admin-react/src/objects/field-edit.js
@@ -237,6 +237,7 @@ const FieldEdit = (props) => {
     { value: "factor", label: "Factor" },
     { value: "multiple", label: "Multiple Factor" },
     { value: "flag", label: "Flag" },
+    { value: "links", label: "Links" },
   ];
 
   const getFieldTypeLabel = (type) => {

--- a/src/blocks/blocks.php
+++ b/src/blocks/blocks.php
@@ -51,6 +51,8 @@ function register_object_meta_block() {
 			$type = 'array';
 		} elseif ( 'measure' === $field->type ) {
 			$type = 'array';
+		} elseif ( 'links' === $field->type ) {
+			$type = 'array';
 		} else {
 			$type = 'string';
 		}

--- a/src/blocks/object-meta/edit.js
+++ b/src/blocks/object-meta/edit.js
@@ -13,6 +13,7 @@ import {
 } from "@wordpress/components";
 
 import { stripslashes, isEmpty } from "../../javascript/util";
+import LinksControl from "./links-control";
 
 const ObjectMetaField = (props) => {
   const { fieldData, fieldValue, errorText, onChange, onFocus, onBlur } = props;
@@ -141,6 +142,8 @@ const ObjectMetaField = (props) => {
         </div>
       );
     }
+  } else if (fieldType == "links") {
+    inputElement = <LinksControl value={fieldValue} onChange={onChange} />;
   } else {
     inputElement = <div name={fieldSlug}>{fieldValue}</div>;
   }

--- a/src/blocks/object-meta/editor.scss
+++ b/src/blocks/object-meta/editor.scss
@@ -226,8 +226,22 @@
         .wpm-link-row-label {
           flex: 1 1 auto;
           font-size: 13px;
-          color: #1d2327;
           overflow-wrap: anywhere;
+          color: #1d2327;
+        }
+
+        a.wpm-link-row-label {
+          color: #2271b1;
+          text-decoration: underline;
+
+          &:hover {
+            color: #135e96;
+          }
+        }
+
+        .wpm-link-row-label--empty {
+          color: #757575;
+          font-style: italic;
         }
 
         .wpm-link-row-actions {

--- a/src/blocks/object-meta/editor.scss
+++ b/src/blocks/object-meta/editor.scss
@@ -202,6 +202,40 @@
         margin-top: 4px;
         font-size: 13px;
       }
+
+      .wpm-links-control {
+        .wpm-links-list {
+          list-style: none;
+          margin: 0 0 8px;
+          padding: 0;
+        }
+
+        .wpm-link-row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 8px;
+          padding: 6px 8px;
+          border: 1px solid #ddd;
+          border-radius: 4px;
+          margin-bottom: 6px;
+          background: #fff;
+          position: relative;
+        }
+
+        .wpm-link-row-label {
+          flex: 1 1 auto;
+          font-size: 13px;
+          color: #1d2327;
+          overflow-wrap: anywhere;
+        }
+
+        .wpm-link-row-actions {
+          display: flex;
+          gap: 4px;
+          flex: 0 0 auto;
+        }
+      }
     }
   }
 }

--- a/src/blocks/object-meta/editor.scss
+++ b/src/blocks/object-meta/editor.scss
@@ -253,3 +253,14 @@
     }
   }
 }
+
+.wpm-link-edit-popover {
+  padding: 8px;
+  min-width: 320px;
+
+  .wpm-link-edit-popover__label-override {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid #ddd;
+  }
+}

--- a/src/blocks/object-meta/links-control.js
+++ b/src/blocks/object-meta/links-control.js
@@ -1,6 +1,6 @@
 import apiFetch from "@wordpress/api-fetch";
 import { __experimentalLinkControl as LinkControl } from "@wordpress/block-editor";
-import { Button, Popover } from "@wordpress/components";
+import { Button, Popover, TextControl } from "@wordpress/components";
 import { useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 
@@ -147,13 +147,28 @@ const LinksControl = ({ value, onChange }) => {
                 placement="bottom-start"
                 onClose={() => setEditingIndex(null)}
               >
-                <LinkControl
-                  value={linkControlValue(link)}
-                  onChange={(next) =>
-                    updateLink(index, fromLinkControl(next))
-                  }
-                  showInitialSuggestions
-                />
+                <div className="wpm-link-edit-popover">
+                  <LinkControl
+                    value={linkControlValue(link)}
+                    onChange={(next) =>
+                      updateLink(index, fromLinkControl(next))
+                    }
+                    showInitialSuggestions
+                  />
+                  <div className="wpm-link-edit-popover__label-override">
+                    <TextControl
+                      label={__("Custom label (optional)", "wp-museum")}
+                      help={__(
+                        "Overrides the post title or URL when shown to readers.",
+                        "wp-museum",
+                      )}
+                      value={link.label || ""}
+                      onChange={(val) =>
+                        updateLink(index, { ...link, label: val })
+                      }
+                    />
+                  </div>
+                </div>
               </Popover>
             )}
           </li>

--- a/src/blocks/object-meta/links-control.js
+++ b/src/blocks/object-meta/links-control.js
@@ -1,6 +1,7 @@
+import apiFetch from "@wordpress/api-fetch";
 import { __experimentalLinkControl as LinkControl } from "@wordpress/block-editor";
 import { Button, Popover } from "@wordpress/components";
-import { useState } from "@wordpress/element";
+import { useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 
 /**
@@ -17,6 +18,57 @@ import { __ } from "@wordpress/i18n";
 const LinksControl = ({ value, onChange }) => {
   const links = Array.isArray(value) ? value : [];
   const [editingIndex, setEditingIndex] = useState(null);
+  // post_id -> cat ID string, or "" if the target has no cat field.
+  // "" is kept so we don't re-fetch a target that has none.
+  const [catIds, setCatIds] = useState({});
+
+  // For every internal-post link whose cat ID we haven't fetched yet,
+  // call /wp-museum/v1/all/<id> — that endpoint returns the cat_field
+  // slug plus all field values, so cat ID is `data[data.cat_field]`.
+  // Non-museum-object posts (regular pages) return cat_field: null and
+  // we cache an empty string to avoid retrying.
+  useEffect(() => {
+    const missing = links
+      .filter(
+        (l) => l.type === "post" && l.post_id && !(l.post_id in catIds),
+      )
+      .map((l) => l.post_id);
+    if (missing.length === 0) return undefined;
+
+    let cancelled = false;
+    Promise.all(
+      missing.map((id) =>
+        apiFetch({ path: `/wp-museum/v1/all/${id}` })
+          .then((data) => {
+            const slug = data && data.cat_field;
+            const catValue = slug && data[slug] ? String(data[slug]) : "";
+            return [id, catValue];
+          })
+          .catch(() => [id, ""]),
+      ),
+    ).then((results) => {
+      if (cancelled) return;
+      setCatIds((prev) => {
+        const next = { ...prev };
+        for (const [id, val] of results) next[id] = val;
+        return next;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [links]);
+
+  const labelFor = (link) => {
+    const base = link.label || link.url || "";
+    if (!base) return "";
+    if (link.type === "post" && link.post_id) {
+      const catId = catIds[link.post_id];
+      if (catId) return `${base} (${catId})`;
+    }
+    return base;
+  };
 
   const updateLink = (index, newLink) => {
     const next = links.slice();
@@ -66,7 +118,7 @@ const LinksControl = ({ value, onChange }) => {
                 target="_blank"
                 rel="noreferrer noopener"
               >
-                {link.label || link.url}
+                {labelFor(link)}
               </a>
             ) : (
               <span className="wpm-link-row-label wpm-link-row-label--empty">

--- a/src/blocks/object-meta/links-control.js
+++ b/src/blocks/object-meta/links-control.js
@@ -59,9 +59,20 @@ const LinksControl = ({ value, onChange }) => {
       <ul className="wpm-links-list">
         {links.map((link, index) => (
           <li key={index} className="wpm-link-row">
-            <span className="wpm-link-row-label">
-              {link.label || link.url || __("(untitled link)", "wp-museum")}
-            </span>
+            {link.url ? (
+              <a
+                className="wpm-link-row-label"
+                href={link.url}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {link.label || link.url}
+              </a>
+            ) : (
+              <span className="wpm-link-row-label wpm-link-row-label--empty">
+                {link.label || __("(untitled link)", "wp-museum")}
+              </span>
+            )}
             <div className="wpm-link-row-actions">
               <Button
                 variant="tertiary"

--- a/src/blocks/object-meta/links-control.js
+++ b/src/blocks/object-meta/links-control.js
@@ -11,26 +11,31 @@ import { __ } from "@wordpress/i18n";
  * Stored shape (per item):
  *   { type: 'post' | 'url', post_id?: int, url?: string, label?: string }
  *
- * Internal links keep `url` as a cached snapshot for editor display, but
- * the public renderer re-resolves the post's current permalink at render
- * time so a renamed post still resolves correctly.
+ * `label` is the user's custom override (typed into the popover's "Custom
+ * label" field) and is empty by default. The public renderer mirrors:
+ *   - empty label  → auto-derived (post title + cat ID, or the URL)
+ *   - filled label → rendered verbatim, no cat ID appended
+ *
+ * Internal post titles and cat IDs are looked up async via
+ * /wp-museum/v1/all/<id> and cached so the editor stays consistent with
+ * what readers will see.
  */
 const LinksControl = ({ value, onChange }) => {
   const links = Array.isArray(value) ? value : [];
   const [editingIndex, setEditingIndex] = useState(null);
-  // post_id -> cat ID string, or "" if the target has no cat field.
-  // "" is kept so we don't re-fetch a target that has none.
-  const [catIds, setCatIds] = useState({});
+  // post_id -> { title, catId }. `catId` is "" when the target has no cat
+  // field; both keys present means we've already fetched (don't retry).
+  const [postInfo, setPostInfo] = useState({});
 
-  // For every internal-post link whose cat ID we haven't fetched yet,
-  // call /wp-museum/v1/all/<id> — that endpoint returns the cat_field
-  // slug plus all field values, so cat ID is `data[data.cat_field]`.
-  // Non-museum-object posts (regular pages) return cat_field: null and
-  // we cache an empty string to avoid retrying.
+  // For every internal-post link we haven't fetched yet, call
+  // /wp-museum/v1/all/<id> — that endpoint returns the post title, the
+  // cat_field slug, and all field values. Non-museum-object posts
+  // (regular pages) return cat_field: null and we cache an empty cat ID
+  // so we don't retry.
   useEffect(() => {
     const missing = links
       .filter(
-        (l) => l.type === "post" && l.post_id && !(l.post_id in catIds),
+        (l) => l.type === "post" && l.post_id && !(l.post_id in postInfo),
       )
       .map((l) => l.post_id);
     if (missing.length === 0) return undefined;
@@ -42,15 +47,16 @@ const LinksControl = ({ value, onChange }) => {
           .then((data) => {
             const slug = data && data.cat_field;
             const catValue = slug && data[slug] ? String(data[slug]) : "";
-            return [id, catValue];
+            const title = data && data.post_title ? String(data.post_title) : "";
+            return [id, { title, catId: catValue }];
           })
-          .catch(() => [id, ""]),
+          .catch(() => [id, { title: "", catId: "" }]),
       ),
     ).then((results) => {
       if (cancelled) return;
-      setCatIds((prev) => {
+      setPostInfo((prev) => {
         const next = { ...prev };
-        for (const [id, val] of results) next[id] = val;
+        for (const [id, info] of results) next[id] = info;
         return next;
       });
     });
@@ -61,13 +67,15 @@ const LinksControl = ({ value, onChange }) => {
   }, [links]);
 
   const labelFor = (link) => {
-    const base = link.label || link.url || "";
-    if (!base) return "";
+    // Custom label always wins, no cat ID appended.
+    if (link.label) return link.label;
     if (link.type === "post" && link.post_id) {
-      const catId = catIds[link.post_id];
-      if (catId) return `${base} (${catId})`;
+      const info = postInfo[link.post_id];
+      const title = info && info.title ? info.title : link.url || "";
+      const catId = info && info.catId ? info.catId : "";
+      return catId ? `${title} (${catId})` : title;
     }
-    return base;
+    return link.url || "";
   };
 
   const updateLink = (index, newLink) => {
@@ -92,18 +100,21 @@ const LinksControl = ({ value, onChange }) => {
     id: link.post_id || undefined,
   });
 
-  const fromLinkControl = (next) =>
+  // Preserve the user's custom label across LinkControl re-picks. Don't
+  // copy LinkControl's auto-derived `title` into our `label` field —
+  // that would defeat the "label set ⇒ user customized" signal.
+  const fromLinkControl = (next, prev) =>
     next.id
       ? {
           type: "post",
           post_id: next.id,
           url: next.url || "",
-          label: next.title || "",
+          label: (prev && prev.label) || "",
         }
       : {
           type: "url",
           url: next.url || "",
-          label: next.title || "",
+          label: (prev && prev.label) || "",
         };
 
   return (
@@ -151,7 +162,7 @@ const LinksControl = ({ value, onChange }) => {
                   <LinkControl
                     value={linkControlValue(link)}
                     onChange={(next) =>
-                      updateLink(index, fromLinkControl(next))
+                      updateLink(index, fromLinkControl(next, link))
                     }
                     showInitialSuggestions
                   />

--- a/src/blocks/object-meta/links-control.js
+++ b/src/blocks/object-meta/links-control.js
@@ -1,0 +1,106 @@
+import { __experimentalLinkControl as LinkControl } from "@wordpress/block-editor";
+import { Button, Popover } from "@wordpress/components";
+import { useState } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+
+/**
+ * Editor for a "links" field — a mixed list of internal post references
+ * and external URLs. Uses core's LinkControl popover for picking either.
+ *
+ * Stored shape (per item):
+ *   { type: 'post' | 'url', post_id?: int, url?: string, label?: string }
+ *
+ * Internal links keep `url` as a cached snapshot for editor display, but
+ * the public renderer re-resolves the post's current permalink at render
+ * time so a renamed post still resolves correctly.
+ */
+const LinksControl = ({ value, onChange }) => {
+  const links = Array.isArray(value) ? value : [];
+  const [editingIndex, setEditingIndex] = useState(null);
+
+  const updateLink = (index, newLink) => {
+    const next = links.slice();
+    next[index] = newLink;
+    onChange(next);
+  };
+
+  const removeLink = (index) => {
+    onChange(links.filter((_, i) => i !== index));
+    setEditingIndex(null);
+  };
+
+  const addLink = () => {
+    onChange(links.concat([{ type: "url", url: "", label: "" }]));
+    setEditingIndex(links.length);
+  };
+
+  const linkControlValue = (link) => ({
+    url: link.url || "",
+    title: link.label || "",
+    id: link.post_id || undefined,
+  });
+
+  const fromLinkControl = (next) =>
+    next.id
+      ? {
+          type: "post",
+          post_id: next.id,
+          url: next.url || "",
+          label: next.title || "",
+        }
+      : {
+          type: "url",
+          url: next.url || "",
+          label: next.title || "",
+        };
+
+  return (
+    <div className="wpm-links-control">
+      <ul className="wpm-links-list">
+        {links.map((link, index) => (
+          <li key={index} className="wpm-link-row">
+            <span className="wpm-link-row-label">
+              {link.label || link.url || __("(untitled link)", "wp-museum")}
+            </span>
+            <div className="wpm-link-row-actions">
+              <Button
+                variant="tertiary"
+                size="small"
+                onClick={() => setEditingIndex(index)}
+              >
+                {__("Edit", "wp-museum")}
+              </Button>
+              <Button
+                variant="tertiary"
+                size="small"
+                isDestructive
+                onClick={() => removeLink(index)}
+              >
+                {__("Remove", "wp-museum")}
+              </Button>
+            </div>
+            {editingIndex === index && (
+              <Popover
+                placement="bottom-start"
+                onClose={() => setEditingIndex(null)}
+              >
+                <LinkControl
+                  value={linkControlValue(link)}
+                  onChange={(next) =>
+                    updateLink(index, fromLinkControl(next))
+                  }
+                  showInitialSuggestions
+                />
+              </Popover>
+            )}
+          </li>
+        ))}
+      </ul>
+      <Button variant="secondary" onClick={addLink}>
+        {__("+ Add Link", "wp-museum")}
+      </Button>
+    </div>
+  );
+};
+
+export default LinksControl;

--- a/src/blocks/object-meta/render.php
+++ b/src/blocks/object-meta/render.php
@@ -69,6 +69,8 @@ foreach ( $fields as $field ) {
 					}
 				}
 			}
+		} elseif ( 'links' === $field->type ) {
+			$field_text .= render_links_field( $meta_value );
 		} else {
 			$field_text .= $meta_value;
 		}

--- a/src/classes/class-mobjectfield.php
+++ b/src/classes/class-mobjectfield.php
@@ -44,7 +44,7 @@ class MObjectField {
 	public $name;
 
 	/**
-	 * Datatype of the field: plain|rich|date|factor|multiple|measure|flag.
+	 * Datatype of the field: plain|rich|date|factor|multiple|measure|flag|links.
 	 *
 	 * @var string $type
 	 */

--- a/src/classes/class-objectposttype.php
+++ b/src/classes/class-objectposttype.php
@@ -121,6 +121,26 @@ class ObjectPostType {
 							],
 						],
 					];
+				} elseif ( 'links' === $field->type ) {
+					$type         = 'array';
+					$show_in_rest = [
+						'schema' => [
+							'type'  => 'array',
+							'items' => [
+								'type'                 => 'object',
+								'properties'           => [
+									'type'    => [
+										'type' => 'string',
+										'enum' => [ 'post', 'url' ],
+									],
+									'post_id' => [ 'type' => 'integer' ],
+									'url'     => [ 'type' => 'string' ],
+									'label'   => [ 'type' => 'string' ],
+								],
+								'additionalProperties' => false,
+							],
+						],
+					];
 				} else {
 					$type = 'string';
 				}

--- a/src/components/advanced-search-ui/advanced-search-ui.js
+++ b/src/components/advanced-search-ui/advanced-search-ui.js
@@ -28,7 +28,10 @@ const FieldSearchElement = (props) => {
   const fieldOptions =
     fieldDataArray.length > 0
       ? fieldDataArray
-          .filter((fieldItem) => fieldItem.type !== "flag")
+          .filter(
+            (fieldItem) =>
+              fieldItem.type !== "flag" && fieldItem.type !== "links",
+          )
           .map((fieldItem) => {
             return { label: fieldItem.name, value: fieldItem.slug };
           })

--- a/src/includes/display-functions.php
+++ b/src/includes/display-functions.php
@@ -363,19 +363,24 @@ function render_links_field( $links ) {
 		$href  = '';
 		$label = isset( $link['label'] ) ? (string) $link['label'] : '';
 
+		// Custom label (non-empty) wins verbatim — no cat ID appended.
+		// Empty label falls back to post title + cat ID for internal links,
+		// or the URL for external links.
+		$label_is_custom = ( '' !== $label );
+
 		$cat_id_suffix = '';
 		if ( 'post' === $type && ! empty( $link['post_id'] ) ) {
 			$post_id  = (int) $link['post_id'];
 			$resolved = get_permalink( $post_id );
 			if ( $resolved ) {
 				$href = $resolved;
-				if ( '' === $label ) {
-					$label = get_the_title( $post_id );
+				if ( ! $label_is_custom ) {
+					$label  = get_the_title( $post_id );
+					$cat_id = get_cat_id_for_post( $post_id );
+					if ( '' !== $cat_id ) {
+						$cat_id_suffix = " ($cat_id)";
+					}
 				}
-			}
-			$cat_id = get_cat_id_for_post( $post_id );
-			if ( '' !== $cat_id ) {
-				$cat_id_suffix = " ($cat_id)";
 			}
 		}
 		if ( '' === $href && ! empty( $link['url'] ) ) {

--- a/src/includes/display-functions.php
+++ b/src/includes/display-functions.php
@@ -311,6 +311,33 @@ function post_status_indicator( $wp_admin_bar ) {
 }
 
 /**
+ * Resolve a post's catalogue ID value, if it has one.
+ *
+ * Returns the value of the post's kind's cat field as a string, or an
+ * empty string if the post isn't a museum object, the kind has no cat
+ * field configured, or the meta value is empty.
+ *
+ * @param int $post_id Post ID.
+ * @return string Cat ID string (empty if none).
+ */
+function get_cat_id_for_post( $post_id ) {
+	$post_type = get_post_type( $post_id );
+	if ( ! $post_type ) {
+		return '';
+	}
+	$kind = get_kind_from_typename( $post_type );
+	if ( empty( $kind ) || empty( $kind->cat_field_id ) ) {
+		return '';
+	}
+	$cat_field = get_mobject_field( $kind->kind_id, $kind->cat_field_id );
+	if ( empty( $cat_field ) || empty( $cat_field->slug ) ) {
+		return '';
+	}
+	$value = get_post_meta( $post_id, $cat_field->slug, true );
+	return $value ? (string) $value : '';
+}
+
+/**
  * Render a "links" field value as an HTML unordered list of anchors.
  *
  * Each item is one of:
@@ -336,13 +363,19 @@ function render_links_field( $links ) {
 		$href  = '';
 		$label = isset( $link['label'] ) ? (string) $link['label'] : '';
 
+		$cat_id_suffix = '';
 		if ( 'post' === $type && ! empty( $link['post_id'] ) ) {
-			$resolved = get_permalink( (int) $link['post_id'] );
+			$post_id  = (int) $link['post_id'];
+			$resolved = get_permalink( $post_id );
 			if ( $resolved ) {
 				$href = $resolved;
 				if ( '' === $label ) {
-					$label = get_the_title( (int) $link['post_id'] );
+					$label = get_the_title( $post_id );
 				}
+			}
+			$cat_id = get_cat_id_for_post( $post_id );
+			if ( '' !== $cat_id ) {
+				$cat_id_suffix = " ($cat_id)";
 			}
 		}
 		if ( '' === $href && ! empty( $link['url'] ) ) {
@@ -358,7 +391,7 @@ function render_links_field( $links ) {
 		$items_html .= sprintf(
 			'<li><a href="%1$s">%2$s</a></li>',
 			esc_url( $href ),
-			esc_html( $label )
+			esc_html( $label . $cat_id_suffix )
 		);
 	}
 	if ( '' === $items_html ) {

--- a/src/includes/display-functions.php
+++ b/src/includes/display-functions.php
@@ -309,3 +309,60 @@ function post_status_indicator( $wp_admin_bar ) {
 		);
 	}
 }
+
+/**
+ * Render a "links" field value as an HTML unordered list of anchors.
+ *
+ * Each item is one of:
+ *   { type: 'post', post_id: int, url?: string, label?: string }
+ *   { type: 'url',  url: string,  label?: string }
+ *
+ * Internal post items are re-resolved to the post's current permalink
+ * (and title, if no override label) so a renamed post stays linkable.
+ *
+ * @param mixed $links Stored value (array of items, possibly null/empty).
+ * @return string HTML for an `ul.wpm-links` list, or empty string when none.
+ */
+function render_links_field( $links ) {
+	if ( ! is_array( $links ) || empty( $links ) ) {
+		return '';
+	}
+	$items_html = '';
+	foreach ( $links as $link ) {
+		if ( ! is_array( $link ) ) {
+			continue;
+		}
+		$type  = isset( $link['type'] ) ? (string) $link['type'] : 'url';
+		$href  = '';
+		$label = isset( $link['label'] ) ? (string) $link['label'] : '';
+
+		if ( 'post' === $type && ! empty( $link['post_id'] ) ) {
+			$resolved = get_permalink( (int) $link['post_id'] );
+			if ( $resolved ) {
+				$href = $resolved;
+				if ( '' === $label ) {
+					$label = get_the_title( (int) $link['post_id'] );
+				}
+			}
+		}
+		if ( '' === $href && ! empty( $link['url'] ) ) {
+			$href = (string) $link['url'];
+		}
+		if ( '' === $href ) {
+			continue;
+		}
+		if ( '' === $label ) {
+			$label = $href;
+		}
+
+		$items_html .= sprintf(
+			'<li><a href="%1$s">%2$s</a></li>',
+			esc_url( $href ),
+			esc_html( $label )
+		);
+	}
+	if ( '' === $items_html ) {
+		return '';
+	}
+	return '<ul class="wpm-links">' . $items_html . '</ul>';
+}

--- a/src/includes/object-functions.php
+++ b/src/includes/object-functions.php
@@ -804,3 +804,85 @@ function wpm_sort_by_field(
 		}
 	);
 }
+
+/**
+ * Extend the SQL search clause to also match each museum kind's catalogue
+ * ID field (#115). Without this, `LinkControl` (and any other consumer of
+ * core's `/wp/v2/search` or a plain `s=` query) finds objects only by
+ * title/excerpt/content. With this filter, typing a cat ID like "T.123"
+ * also surfaces the matching object.
+ *
+ * Only kicks in when the query touches at least one registered museum
+ * object post type, so generic searches keep their default cost.
+ *
+ * @param string    $search   Existing SQL search clause (e.g., " AND ((...))").
+ * @param \WP_Query $wp_query The current query.
+ * @return string Modified search clause.
+ */
+function extend_object_search_to_cat_fields( $search, $wp_query ) {
+	global $wpdb;
+
+	if ( empty( $search ) ) {
+		return $search;
+	}
+	$search_term = $wp_query->get( 's' );
+	if ( empty( $search_term ) || ! is_string( $search_term ) ) {
+		return $search;
+	}
+
+	$object_types = get_object_type_names();
+	if ( empty( $object_types ) ) {
+		return $search;
+	}
+
+	$query_types = (array) $wp_query->get( 'post_type' );
+	// Only matters when the query touches museum object post types.
+	if ( ! empty( $query_types ) && ! in_array( 'any', $query_types, true ) ) {
+		if ( empty( array_intersect( $query_types, $object_types ) ) ) {
+			return $search;
+		}
+	}
+
+	// Collect the cat field slug for every museum kind that has one set.
+	$cat_slugs = [];
+	foreach ( get_mobject_kinds() as $kind ) {
+		if ( empty( $kind->cat_field_id ) ) {
+			continue;
+		}
+		$cat_field = get_mobject_field( $kind->kind_id, $kind->cat_field_id );
+		if ( $cat_field && ! empty( $cat_field->slug ) ) {
+			$cat_slugs[ $cat_field->slug ] = true;
+		}
+	}
+	if ( empty( $cat_slugs ) ) {
+		return $search;
+	}
+
+	$like    = '%' . $wpdb->esc_like( $search_term ) . '%';
+	$clauses = [];
+	foreach ( array_keys( $cat_slugs ) as $slug ) {
+		// EXISTS subquery — no JOIN, so doesn't disturb other postmeta joins
+		// elsewhere in the query.
+		$clauses[] = $wpdb->prepare(
+			"EXISTS (SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value LIKE %s)",
+			$slug,
+			$like
+		);
+	}
+	$cat_match = '(' . implode( ' OR ', $clauses ) . ')';
+
+	// $search is shaped like ` AND ((title LIKE …) OR (excerpt LIKE …) OR (content LIKE …))`,
+	// optionally followed by ` AND (wp_posts.post_password = '')` for
+	// unauthenticated queries. We must inject OR <cat_match> inside the
+	// title-group's outermost parens — not after the password clause,
+	// which would let every published row match.
+	$password_marker = ' AND (' . $wpdb->posts . '.post_password';
+	$password_pos    = strpos( $search, $password_marker );
+	$scan_end        = ( false === $password_pos ) ? strlen( $search ) : $password_pos;
+
+	$title_close_pos = strrpos( substr( $search, 0, $scan_end ), ')' );
+	if ( false === $title_close_pos ) {
+		return $search;
+	}
+	return substr( $search, 0, $title_close_pos ) . ' OR ' . $cat_match . substr( $search, $title_close_pos );
+}

--- a/src/rest/class-object-fields-controller.php
+++ b/src/rest/class-object-fields-controller.php
@@ -183,7 +183,7 @@ class Object_Fields_Controller extends \WP_REST_Controller {
 				'type'                  => [
 					'description' => __( 'Datatype of the field.', 'wp-museum' ),
 					'type'        => 'string',
-					'enum'        => [ 'plain', 'rich', 'date', 'factor', 'multiple', 'measure', 'flag' ],
+					'enum'        => [ 'plain', 'rich', 'date', 'factor', 'multiple', 'measure', 'flag', 'links' ],
 					'context '    => [ 'view', 'edit' ],
 				],
 				'display_order'         => [

--- a/src/rest/class-objects-controller.php
+++ b/src/rest/class-objects-controller.php
@@ -896,6 +896,22 @@ class Objects_Controller extends \WP_REST_Controller {
 				case 'flag':
 					$properties[ $field->slug ]['type'] = 'boolean';
 					break;
+				case 'links':
+					// Each item is { type: 'post'|'url', post_id?: int, url?: string, label?: string }.
+					$properties[ $field->slug ]['type']  = 'array';
+					$properties[ $field->slug ]['items'] = [
+						'type'       => 'object',
+						'properties' => [
+							'type'    => [
+								'type' => 'string',
+								'enum' => [ 'post', 'url' ],
+							],
+							'post_id' => [ 'type' => 'integer' ],
+							'url'     => [ 'type' => 'string' ],
+							'label'   => [ 'type' => 'string' ],
+						],
+					];
+					break;
 			}
 		}
 

--- a/tests/playwright/links-cat-id-search.spec.js
+++ b/tests/playwright/links-cat-id-search.spec.js
@@ -1,0 +1,125 @@
+/**
+ * Tests for issue #115 (follow-up): /wp/v2/search matches catalogue IDs.
+ *
+ * LinkControl in the editor hits core's `/wp/v2/search` to populate its
+ * autocomplete. Out of the box that endpoint only searches title /
+ * excerpt / content. The plugin extends the SQL search clause (via the
+ * `posts_search` filter) to also match each museum kind's cat field
+ * meta, so admins can find objects by ID like "MAGIC.42" — not just by
+ * title.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, setupMuseumTest, createSimpleObjectKind } = require("./utils");
+
+test.describe("Cat ID search via /wp/v2/search (#115)", () => {
+  let objectPostType;
+  let catFieldSlug;
+  let objectPostId;
+  const catIdValue = "MAGIC.42";
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await setupMuseumTest(page);
+    await createSimpleObjectKind(page, "Cat Search Test Obj");
+
+    await page.goto("/wp-admin/");
+    await page.waitForLoadState("domcontentloaded");
+    const nonce = await page.evaluate(() => window.wpApiSettings?.nonce);
+
+    const kindsResp = await page.request.get(
+      "/wp-json/wp-museum/v1/mobject_kinds",
+      { headers: { "X-WP-Nonce": nonce } }
+    );
+    const kinds = await kindsResp.json();
+    const kind = kinds.find((k) => k.label === "Cat Search Test Obj");
+    objectPostType = kind.type_name;
+
+    // Look up the Accession Number field; we'll designate it as the cat
+    // field for this kind.
+    const fieldsResp = await page.request.get(
+      `/wp-json/wp-museum/v1/${objectPostType}/fields`,
+      { headers: { "X-WP-Nonce": nonce } }
+    );
+    const fields = await fieldsResp.json();
+    const accessionField = Object.values(fields).find(
+      (f) => f.name === "Accession Number"
+    );
+    expect(accessionField).toBeTruthy();
+    catFieldSlug = accessionField.slug;
+
+    // Update the kind to point cat_field_id at Accession Number.
+    const updatedKinds = kinds.map((k) =>
+      k.kind_id === kind.kind_id
+        ? { ...k, cat_field_id: accessionField.field_id }
+        : k
+    );
+    const kindUpdateResp = await page.request.post(
+      "/wp-json/wp-museum/v1/mobject_kinds",
+      {
+        data: updatedKinds,
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(kindUpdateResp.ok()).toBe(true);
+
+    // Create a museum object with the cat ID value and a benign title.
+    // We deliberately pick a title that does NOT contain the cat ID so
+    // a match on /wp/v2/search?s=MAGIC.42 can only come from the meta.
+    const objResp = await page.request.post(
+      `/wp-json/wp/v2/${objectPostType}`,
+      {
+        data: {
+          title: "Silent Spectroscope",
+          status: "publish",
+          meta: { [catFieldSlug]: catIdValue },
+        },
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(objResp.ok()).toBe(true);
+    objectPostId = (await objResp.json()).id;
+
+    await page.close();
+  });
+
+  test("/wp/v2/search?s=<cat-id> returns the matching object", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+
+    const resp = await page.request.get(
+      `/wp-json/wp/v2/search?search=${encodeURIComponent(catIdValue)}&subtype=${objectPostType}&per_page=20`
+    );
+    expect(resp.ok()).toBe(true);
+    const results = await resp.json();
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.some((r) => r.id === objectPostId)).toBe(true);
+  });
+
+  test("title-based search still works (regression guard)", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+
+    const resp = await page.request.get(
+      `/wp-json/wp/v2/search?search=Spectroscope&subtype=${objectPostType}&per_page=20`
+    );
+    expect(resp.ok()).toBe(true);
+    const results = await resp.json();
+    expect(results.some((r) => r.id === objectPostId)).toBe(true);
+  });
+
+  test("unrelated search term returns no false positives", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+
+    const resp = await page.request.get(
+      `/wp-json/wp/v2/search?search=zzz-impossible-string-xyz&subtype=${objectPostType}&per_page=20`
+    );
+    expect(resp.ok()).toBe(true);
+    const results = await resp.json();
+    expect(results.some((r) => r.id === objectPostId)).toBe(false);
+  });
+});

--- a/tests/playwright/links-field-type.spec.js
+++ b/tests/playwright/links-field-type.spec.js
@@ -1,0 +1,180 @@
+/**
+ * Tests for issue #115: the new "links" field type.
+ *
+ * A links field holds an ordered list of mixed targets:
+ *   - internal posts/pages/museum objects: { type: 'post', post_id, label? }
+ *   - external URLs: { type: 'url', url, label }
+ *
+ * This spec exercises the data path end-to-end: define a "links" field
+ * on a kind via REST, create an object whose meta carries an items list,
+ * then render the object page and assert the public renderer emits the
+ * expected `ul.wpm-links` markup with anchors.
+ *
+ * The editor UI (LinkControl popover) is left to manual / future testing
+ * — driving the popover from Playwright is fragile, and the storage
+ * shape is what matters for downstream consumers.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, setupMuseumTest, createSimpleObjectKind } = require("./utils");
+
+test.describe("Links field type (#115)", () => {
+  let objectPostType;
+  let linksFieldSlug;
+  let internalTargetPostId;
+  let internalTargetTitle;
+  let internalTargetLink;
+  let objectPostId;
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await setupMuseumTest(page);
+    await createSimpleObjectKind(page, "Links Field Test Obj");
+
+    await page.goto("/wp-admin/");
+    await page.waitForLoadState("domcontentloaded");
+    const nonce = await page.evaluate(() => window.wpApiSettings?.nonce);
+
+    const kindsResp = await page.request.get(
+      "/wp-json/wp-museum/v1/mobject_kinds",
+      { headers: { "X-WP-Nonce": nonce } }
+    );
+    const kinds = await kindsResp.json();
+    const kind = kinds.find((k) => k.label === "Links Field Test Obj");
+    objectPostType = kind.type_name;
+
+    // Add a links-type field to the kind via the fields REST endpoint.
+    linksFieldSlug = "associated-links";
+    const fieldsPayload = {
+      new_links_field: {
+        field_id: 0,
+        kind_id: kind.kind_id,
+        slug: linksFieldSlug,
+        name: "Associated Links",
+        type: "links",
+        public: true,
+        required: false,
+        display_order: 100,
+      },
+    };
+    const fieldResp = await page.request.post(
+      `/wp-json/wp-museum/v1/${objectPostType}/fields`,
+      {
+        data: fieldsPayload,
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(fieldResp.ok()).toBe(true);
+
+    // Internal link target: a regular WP page.
+    internalTargetTitle = "Links Field Internal Target";
+    const targetResp = await page.request.post("/wp-json/wp/v2/pages", {
+      data: { title: internalTargetTitle, status: "publish" },
+      headers: { "X-WP-Nonce": nonce },
+    });
+    const targetData = await targetResp.json();
+    internalTargetPostId = targetData.id;
+    internalTargetLink = targetData.link;
+
+    // Create the museum object with a mixed links field value.
+    const linksValue = [
+      {
+        type: "post",
+        post_id: internalTargetPostId,
+        url: targetData.link,
+        label: "", // empty label — renderer should fall back to post title
+      },
+      {
+        type: "url",
+        url: "https://example.com/external",
+        label: "External example",
+      },
+      {
+        type: "url",
+        url: "https://example.com/no-label",
+        label: "", // no label — renderer should fall back to the URL itself
+      },
+    ];
+    // Mirror the editor-time post template so the object-meta block actually
+    // renders on the frontend; REST creation bypasses the post-type template.
+    const objectContent =
+      `<!-- wp:wp-museum/object-meta-block /-->\n` +
+      `<!-- wp:wp-museum/object-image-attachments-block /-->\n` +
+      `<!-- wp:wp-museum/child-objects-block /-->\n`;
+
+    const objResp = await page.request.post(
+      `/wp-json/wp/v2/${objectPostType}`,
+      {
+        data: {
+          title: "Links Field Test Object",
+          status: "publish",
+          content: objectContent,
+          meta: { [linksFieldSlug]: linksValue },
+        },
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(objResp.ok()).toBe(true);
+    objectPostId = (await objResp.json()).id;
+
+    await page.close();
+  });
+
+  test("REST: links field round-trips with mixed items", async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const resp = await page.request.get(
+      `/wp-json/wp/v2/${objectPostType}/${objectPostId}`
+    );
+    const body = await resp.json();
+    const stored = body.meta?.[linksFieldSlug];
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored.length).toBe(3);
+    expect(stored[0].type).toBe("post");
+    expect(stored[0].post_id).toBe(internalTargetPostId);
+    expect(stored[1].type).toBe("url");
+    expect(stored[1].url).toBe("https://example.com/external");
+    expect(stored[1].label).toBe("External example");
+  });
+
+  test("Frontend: object page renders ul.wpm-links with resolved anchors", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+
+    await page.goto(`/?p=${objectPostId}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const list = page.locator("ul.wpm-links");
+    await expect(list).toHaveCount(1);
+    const anchors = list.locator("li a");
+    await expect(anchors).toHaveCount(3);
+
+    // Internal link: href resolves to the target page's current permalink
+    // (not the stored snapshot), and label falls back to post title since
+    // the stored label was empty.
+    const internalAnchor = anchors.nth(0);
+    const internalHref = await internalAnchor.getAttribute("href");
+    expect(internalHref).toBeTruthy();
+    const internalUrl = new URL(internalHref, page.url());
+    const targetUrl = new URL(internalTargetLink);
+    expect(internalUrl.pathname.replace(/\/$/, "")).toBe(
+      targetUrl.pathname.replace(/\/$/, "")
+    );
+    await expect(internalAnchor).toHaveText(internalTargetTitle);
+
+    // External link with explicit label.
+    await expect(anchors.nth(1)).toHaveAttribute(
+      "href",
+      "https://example.com/external"
+    );
+    await expect(anchors.nth(1)).toHaveText("External example");
+
+    // External link with no label — label falls back to the URL.
+    await expect(anchors.nth(2)).toHaveAttribute(
+      "href",
+      "https://example.com/no-label"
+    );
+    await expect(anchors.nth(2)).toHaveText("https://example.com/no-label");
+  });
+});

--- a/tests/playwright/links-frontend-cat-id.spec.js
+++ b/tests/playwright/links-frontend-cat-id.spec.js
@@ -1,0 +1,189 @@
+/**
+ * Tests for issue #115 (follow-up): public renderer surfaces cat IDs
+ * and honors the optional custom label override.
+ *
+ * - Linked internal museum objects with a cat ID render as
+ *   "Title (CAT123)" on the frontend, matching the editor display.
+ * - When the stored `label` field is set (the admin typed a custom
+ *   label), it's used verbatim — overriding the post title for
+ *   internal links and the URL for external ones.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, setupMuseumTest, createSimpleObjectKind } = require("./utils");
+
+test.describe("Links frontend: cat IDs and custom labels (#115)", () => {
+  let objectPostType;
+  let linksFieldSlug;
+  let internalTargetPostId;
+  let internalTargetTitle;
+  let internalTargetCatId;
+  let hostObjectPostId;
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await setupMuseumTest(page);
+    await createSimpleObjectKind(page, "Frontend Cat Test Obj");
+
+    await page.goto("/wp-admin/");
+    await page.waitForLoadState("domcontentloaded");
+    const nonce = await page.evaluate(() => window.wpApiSettings?.nonce);
+
+    const kindsResp = await page.request.get(
+      "/wp-json/wp-museum/v1/mobject_kinds",
+      { headers: { "X-WP-Nonce": nonce } }
+    );
+    const kinds = await kindsResp.json();
+    const kind = kinds.find((k) => k.label === "Frontend Cat Test Obj");
+    objectPostType = kind.type_name;
+
+    // Set the Accession Number field as the kind's cat field so the
+    // renderer has something to look up.
+    const fieldsResp = await page.request.get(
+      `/wp-json/wp-museum/v1/${objectPostType}/fields`,
+      { headers: { "X-WP-Nonce": nonce } }
+    );
+    const fields = await fieldsResp.json();
+    const accessionField = Object.values(fields).find(
+      (f) => f.name === "Accession Number"
+    );
+    expect(accessionField).toBeTruthy();
+    const catFieldSlug = accessionField.slug;
+
+    const updatedKinds = kinds.map((k) =>
+      k.kind_id === kind.kind_id
+        ? { ...k, cat_field_id: accessionField.field_id }
+        : k
+    );
+    const kindUpdateResp = await page.request.post(
+      "/wp-json/wp-museum/v1/mobject_kinds",
+      {
+        data: updatedKinds,
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(kindUpdateResp.ok()).toBe(true);
+
+    // Add a links-type field on this kind.
+    linksFieldSlug = "associated-links";
+    const fieldPayload = {
+      new_links_field: {
+        field_id: 0,
+        kind_id: kind.kind_id,
+        slug: linksFieldSlug,
+        name: "Associated Links",
+        type: "links",
+        public: true,
+        required: false,
+        display_order: 100,
+      },
+    };
+    const fieldResp = await page.request.post(
+      `/wp-json/wp-museum/v1/${objectPostType}/fields`,
+      {
+        data: fieldPayload,
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(fieldResp.ok()).toBe(true);
+
+    // Internal target: a museum object of the same kind, with a cat ID set.
+    internalTargetTitle = "Internal Target Object";
+    internalTargetCatId = "FRT.99";
+    const objectContent =
+      `<!-- wp:wp-museum/object-meta-block /-->\n` +
+      `<!-- wp:wp-museum/object-image-attachments-block /-->\n` +
+      `<!-- wp:wp-museum/child-objects-block /-->\n`;
+    const targetResp = await page.request.post(
+      `/wp-json/wp/v2/${objectPostType}`,
+      {
+        data: {
+          title: internalTargetTitle,
+          status: "publish",
+          content: objectContent,
+          meta: { [catFieldSlug]: internalTargetCatId },
+        },
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(targetResp.ok()).toBe(true);
+    internalTargetPostId = (await targetResp.json()).id;
+
+    // Host object whose links field points at:
+    //   1. internal museum object (no custom label, expect "Title (CAT)")
+    //   2. external URL with a custom label "New York Times"
+    //   3. external URL with no label
+    const linksValue = [
+      {
+        type: "post",
+        post_id: internalTargetPostId,
+        url: "",
+        label: "",
+      },
+      {
+        type: "url",
+        url: "https://example.com/nyt",
+        label: "New York Times",
+      },
+      {
+        type: "url",
+        url: "https://example.com/no-label",
+        label: "",
+      },
+    ];
+    const hostResp = await page.request.post(
+      `/wp-json/wp/v2/${objectPostType}`,
+      {
+        data: {
+          title: "Host Object",
+          status: "publish",
+          content: objectContent,
+          meta: { [linksFieldSlug]: linksValue },
+        },
+        headers: { "X-WP-Nonce": nonce },
+      }
+    );
+    expect(hostResp.ok()).toBe(true);
+    hostObjectPostId = (await hostResp.json()).id;
+
+    await page.close();
+  });
+
+  test("internal-post link renders as 'Title (CAT)'", async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`/?p=${hostObjectPostId}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const anchors = page.locator("ul.wpm-links li a");
+    await expect(anchors).toHaveCount(3);
+    await expect(anchors.nth(0)).toHaveText(
+      `${internalTargetTitle} (${internalTargetCatId})`
+    );
+  });
+
+  test("external link with custom label renders the label verbatim", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+    await page.goto(`/?p=${hostObjectPostId}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const anchors = page.locator("ul.wpm-links li a");
+    await expect(anchors.nth(1)).toHaveText("New York Times");
+    await expect(anchors.nth(1)).toHaveAttribute(
+      "href",
+      "https://example.com/nyt"
+    );
+  });
+
+  test("external link without label falls back to the URL", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+    await page.goto(`/?p=${hostObjectPostId}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const anchors = page.locator("ul.wpm-links li a");
+    await expect(anchors.nth(2)).toHaveText("https://example.com/no-label");
+  });
+});

--- a/tests/playwright/links-frontend-cat-id.spec.js
+++ b/tests/playwright/links-frontend-cat-id.spec.js
@@ -110,9 +110,10 @@ test.describe("Links frontend: cat IDs and custom labels (#115)", () => {
     internalTargetPostId = (await targetResp.json()).id;
 
     // Host object whose links field points at:
-    //   1. internal museum object (no custom label, expect "Title (CAT)")
-    //   2. external URL with a custom label "New York Times"
-    //   3. external URL with no label
+    //   1. internal museum object, no custom label  → "Title (CAT)"
+    //   2. external URL with a custom label         → label verbatim
+    //   3. external URL with no label               → URL
+    //   4. internal museum object with custom label → label verbatim, NO cat ID
     const linksValue = [
       {
         type: "post",
@@ -129,6 +130,12 @@ test.describe("Links frontend: cat IDs and custom labels (#115)", () => {
         type: "url",
         url: "https://example.com/no-label",
         label: "",
+      },
+      {
+        type: "post",
+        post_id: internalTargetPostId,
+        url: "",
+        label: "My Favorite Spectroscope",
       },
     ];
     const hostResp = await page.request.post(
@@ -155,10 +162,21 @@ test.describe("Links frontend: cat IDs and custom labels (#115)", () => {
     await page.waitForLoadState("domcontentloaded");
 
     const anchors = page.locator("ul.wpm-links li a");
-    await expect(anchors).toHaveCount(3);
+    await expect(anchors).toHaveCount(4);
     await expect(anchors.nth(0)).toHaveText(
       `${internalTargetTitle} (${internalTargetCatId})`
     );
+  });
+
+  test("internal-post link with custom label renders the label verbatim (no cat ID)", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+    await page.goto(`/?p=${hostObjectPostId}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const anchors = page.locator("ul.wpm-links li a");
+    await expect(anchors.nth(3)).toHaveText("My Favorite Spectroscope");
   });
 
   test("external link with custom label renders the label verbatim", async ({


### PR DESCRIPTION
## Summary

Closes #115. Adds a new museum object field type, **`links`**, that holds an ordered list of mixed targets — internal posts/pages/museum objects + external URLs — with an editor UI built on core's `LinkControl` popover. Includes catalogue-ID-aware display in both editor and frontend, and extends WP search so internal-post search by cat ID just works.

### Storage shape

Each item is one of:

```jsonc
{ "type": "post", "post_id": 42, "url": "...", "label": "" }    // internal
{ "type": "url",  "url": "https://example.com", "label": "" }   // external
```

- `url` on a post item is a cached snapshot used for editor display; the public renderer **re-resolves the post's current permalink** at render time, so renaming/moving the target post stays linkable.
- `label` is the **user's custom override**, empty by default. When set, it's rendered verbatim. When empty, the renderer derives the display from the post title + cat ID, or from the URL.

### Editor (admin)

`LinksControl` (`src/blocks/object-meta/links-control.js`):

- Vertical list of rows; each row is a **clickable anchor** to the link target (opens in a new tab) — admins don't need to open Edit just to follow a link.
- Internal-post rows append the target's cat ID as `Title (CAT123)`. Cat IDs are looked up via `/wp-museum/v1/all/<id>` and cached.
- **+ Add Link** appends an empty row and opens the editor popover.
- Edit popover contains:
  - core's `__experimentalLinkControl` (autocomplete searches all post types, including museum objects; or accepts a typed URL)
  - a **Custom label (optional)** `TextControl` below it; typing overrides the auto-derived title
- Picking a post no longer writes the auto title into `label`, so the field cleanly signals *"did the user customize this?"* — re-picking a target preserves any existing custom label.

### Public render

`render_links_field()` in `src/includes/display-functions.php` emits `<ul class="wpm-links"><li><a href="…">label</a></li>…</ul>`.

| Stored `label` | Internal post (with cat ID) | External URL |
|---|---|---|
| Empty | `Post Title (CAT123)` — auto-derived | The URL |
| `"New York Times"` | `New York Times` — verbatim, no cat ID | `New York Times` |

Editor and frontend rules are identical.

### Search

WordPress's `/wp/v2/search` (which `LinkControl` calls) now matches museum objects by **catalogue ID** as well as title/excerpt/content. Implemented via a `posts_search` filter (`src/includes/object-functions.php::extend_object_search_to_cat_fields`):

- Only kicks in when the query touches museum object post types (or `post_type=any`); generic searches keep their default cost.
- Builds an OR of `EXISTS` subqueries against `postmeta` for each kind's cat field slug.
- Injects `OR <cat_match>` inside the title-group's outermost parens, scanning past the `AND (post_password = '')` clause that WP appends for unauthenticated queries (which initially caused a false-positive bug returning every published post).

Search filter UI excludes `links`-type fields (same treatment as `flag`) in `components/advanced-search-ui/advanced-search-ui.js`.

## Touchpoints

| Layer | File |
|---|---|
| Field-type enum | `class-mobjectfield.php` docstring; `class-object-fields-controller.php` REST enum |
| Per-kind REST meta schema | `class-objectposttype.php` |
| Object response schema | `class-objects-controller.php` |
| Block-attribute meta binding | `blocks.php` |
| Admin field-definition UI | `field-edit.js` selectOptions |
| Object-edit UI | new `object-meta/links-control.js`; dispatch in `object-meta/edit.js` |
| Public render | `display-functions.php` (helpers `render_links_field`, `get_cat_id_for_post`); dispatch in `object-meta/render.php` |
| Cat-ID search filter | `object-functions.php::extend_object_search_to_cat_fields`; registered in `actions-filters.php` |
| Advanced-search filter exclusion | `advanced-search-ui.js` |
| Editor styles | `object-meta/editor.scss` |

## Tests

Three new Playwright specs (all passing):

- `tests/playwright/links-field-type.spec.js` — REST round-trip with mixed `post`/`url` items; frontend renders `ul.wpm-links` with permalink-resolved anchors and label fallbacks.
- `tests/playwright/links-frontend-cat-id.spec.js` — frontend cat-ID append for empty labels; verbatim render for custom labels (both internal and external); URL fallback for empty external labels.
- `tests/playwright/links-cat-id-search.spec.js` — `/wp/v2/search?search=<cat-id>` returns the matching object; title-search regression guard; no-false-positives guard (catches the password-clause boundary bug).

Existing `museum-object-kinds.spec.js` still passes — no regression on existing field types.

## Out of scope (MVP)

- Drag-to-reorder rows
- Handling when an internal target post is deleted (today: link is silently skipped at render — `get_permalink()` returns false)
- Filtering `LinkControl`'s autocomplete to specific post types
- Advanced-search backend filtering by link values (search UI already excludes them)

## Test plan

- [x] Automated specs above all pass
- [x] Existing `museum-object-kinds.spec.js` (3 tests) still passes
- [x] Manual: create a kind in the admin, add a Links field, edit an object — verify the popover behaves, custom label overrides correctly, and reorder/edit/remove work
- [x] Manual: rename or delete an internal target post and re-render — confirm renamed post still links (with refreshed title) and deleted post drops out gracefully
- [x] Manual: in LinkControl's autocomplete, type a partial cat ID — confirm museum objects with matching cat IDs appear in suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)