### PR TITLE
Replace deprecated Button props with variant, IconButton with Button

### DIFF
--- a/src/admin-react/src/general/index.tsx
+++ b/src/admin-react/src/general/index.tsx
@@ -119,7 +119,7 @@ const GeneralOptions = () => {
           </div>
 
           <div className="action-buttons">
-            <Button isPrimary onClick={doSave}>
+            <Button variant="primary" onClick={doSave}>
               Save Settings
             </Button>
           </div>

--- a/src/admin-react/src/objects/index.tsx
+++ b/src/admin-react/src/objects/index.tsx
@@ -477,27 +477,27 @@ const Main = (props: MainProps) => {
           <div className="object-action-buttons">
             <Button
               onClick={() => editKind(kindItem)}
-              isSecondary
+              variant="secondary"
             >
               Edit
             </Button>
             <Button
-              isSecondary
+              variant="secondary"
               onClick={() => deleteKind(kindItem)}
             >
               Delete
             </Button>
             <Button
-              isSecondary
+              variant="secondary"
               onClick={() => handleExportCSV(kindItem)}
             >
               Export CSV
             </Button>
-            <Button isSecondary>
+            <Button variant="secondary">
               Import CSV
             </Button>
             <Button
-              isSecondary
+              variant="secondary"
               onClick={() => exportKind(kindItem)}
             >
               Export Kind
@@ -514,10 +514,10 @@ const Main = (props: MainProps) => {
         </div>
         <div className="kinds-list">{kindRows}</div>
         <div className="main-actions">
-          <Button onClick={newKind} isPrimary>
+          <Button onClick={newKind} variant="primary">
             Add New Object Type
           </Button>
-          <Button onClick={handleImportClick} isSecondary>
+          <Button onClick={handleImportClick} variant="secondary">
             Import Object Type
           </Button>
           <input

--- a/src/admin-react/src/remote/index.tsx
+++ b/src/admin-react/src/remote/index.tsx
@@ -235,7 +235,7 @@ const RemoteAdmin = (props: RemoteAdminProps) => {
       )}
 
       <div className="action-buttons">
-        <Button isPrimary onClick={doSave}>
+        <Button variant="primary" onClick={doSave}>
           Save Settings
         </Button>
       </div>

--- a/src/blocks/child-objects/child-kind.tsx
+++ b/src/blocks/child-objects/child-kind.tsx
@@ -53,7 +53,7 @@ const ChildKind = ( props: ChildKindProps ) => {
 			<Button
 				className = 'new-child-object'
 				onClick   = { () => newChildObject( kind ) }
-				isPrimary
+				variant   = 'primary'
 			>
 				New { label }
 			</Button>

--- a/src/blocks/child-objects/child-object.tsx
+++ b/src/blocks/child-objects/child-object.tsx
@@ -93,16 +93,16 @@ const ChildObject = ( props: ChildObjectProps ) => {
 				<div className = 'child-object-actions'>
 					{ edit_link &&
 						<Button
-							href = { decodeHtmlEntities( edit_link ) }
-							isSecondary
+							href    = { decodeHtmlEntities( edit_link ) }
+							variant = 'secondary'
 						>
 							Edit
 						</Button>
 					}
 					{ link &&
 						<Button
-							href = { decodeHtmlEntities( link ) }
-							isSecondary
+							href    = { decodeHtmlEntities( link ) }
+							variant = 'secondary'
 						>
 							View
 						</Button>

--- a/src/blocks/object-image-attachments/edit.tsx
+++ b/src/blocks/object-image-attachments/edit.tsx
@@ -213,7 +213,7 @@ const ObjectImageAttachmentEdit = ( props: ObjectImageAttachmentEditProps ) => {
 	const mediaOpenButton = ( { open }: { open: () => void } ) => (
 			<Button
 				onClick = { open }
-				isPrimary
+				variant = 'primary'
 			>
 				Add Image(s)
 			</Button>

--- a/src/components/advanced-search-ui/advanced-search-ui.tsx
+++ b/src/components/advanced-search-ui/advanced-search-ui.tsx
@@ -410,7 +410,7 @@ const AdvancedSearchUI = (props: AdvancedSearchUIProps) => {
       {inEditor && (
         <div className="advanced-search-editor-buttons">
           <Button
-            isSecondary
+            variant="secondary"
             onClick={() => {
               setSearchValues({});
               // Clear URL parameters when resetting search
@@ -420,7 +420,7 @@ const AdvancedSearchUI = (props: AdvancedSearchUIProps) => {
             Reset Search
           </Button>
           <Button
-            isSecondary
+            variant="secondary"
             onClick={() =>
               // TODO(strict): possible undefined at runtime if inEditor is set
               // without setAttributes; preserved as-is.
@@ -473,7 +473,7 @@ const AdvancedSearchUI = (props: AdvancedSearchUIProps) => {
             }}
           />
           <Button
-            isPrimary
+            variant="primary"
             className="advanced-search-search-button"
             onClick={() => handleSearch(searchValues)}
           >
@@ -561,7 +561,7 @@ const AdvancedSearchUI = (props: AdvancedSearchUIProps) => {
         )}
       </div>
       <Button
-        isPrimary
+        variant="primary"
         className="advanced-search-button"
         onClick={() => {
           const resetValues = {};

--- a/src/components/embedded-search/embedded-search.tsx
+++ b/src/components/embedded-search/embedded-search.tsx
@@ -138,7 +138,7 @@ const EmbeddedSearch = ( props: EmbeddedSearchProps ) => {
 					</div>
 				</div>
 				<Button
-					isPrimary
+					variant   = 'primary'
 					className = 'wpm-embedded-search-button'
 					aria-label = { `${searchButtonText} museum objects` }
 					onClick   = { () => doSearch() }
@@ -147,7 +147,7 @@ const EmbeddedSearch = ( props: EmbeddedSearchProps ) => {
 				</Button>
 				{ showReset &&
 					<Button
-						isSecondary
+						variant   = 'secondary'
 						className = 'wpm-embedded-search-button'
 						aria-label = 'Clear search and reset results'
 						onClick   = { resetSearch }

--- a/src/components/image-selector/image-selector.tsx
+++ b/src/components/image-selector/image-selector.tsx
@@ -14,15 +14,10 @@ import {
 import apiFetch from "@wordpress/api-fetch";
 
 import {
-	IconButton,
+	Button,
 } from '@wordpress/components';
 
 import { getBestImage } from '../../javascript/util';
-
-// NOTE(wp-types): @wordpress/components' deprecated IconButton type
-// resolves its acceptable props to `never`, rejecting the currently-working
-// className/icon/onClick props. Cast to keep behavior unchanged.
-const IconButtonCompat = IconButton as any;
 
 import type { CSSProperties, ReactElement } from 'react';
 
@@ -192,12 +187,12 @@ const ImageSelector: {
 				className = 'image-selector-container'
 				style     = { selectorStyle }
 			>
-				<IconButtonCompat
+				<Button
 					className = 'left-arrow selector-button'
 					icon      = 'arrow-left-alt2'
 					onClick   = { () => updateImageIndex( -1 ) }
 				/>
-				<IconButtonCompat
+				<Button
 					className = 'right-arrow selector-button'
 					icon      = 'arrow-right-alt2'
 					onClick   = { () => updateImageIndex( 1 ) }

--- a/src/components/image-size-panel/image-size-panel.tsx
+++ b/src/components/image-size-panel/image-size-panel.tsx
@@ -162,19 +162,19 @@ const ImageSizePanel = ( props: ImageSizePanelProps ) => {
 					<p>{ __( 'Image Alignment' ) }</p>
 					<ButtonGroup>
 						<Button
-							isPrimary = { imgAlignment === 'left' }
+							variant   = { imgAlignment === 'left' ? 'primary' : undefined }
 							onClick   = { () => { updateimgAlignment( 'left' ) } }
 						>
 							<Dashicon icon = 'align-left'/>
 						</Button>
 						<Button
-							isPrimary = { imgAlignment === 'center' }
+							variant   = { imgAlignment === 'center' ? 'primary' : undefined }
 							onClick   = { () => { updateimgAlignment( 'center' ) } }
 						>
 							<Dashicon icon = 'align-center'/>
 						</Button>
 						<Button
-							isPrimary = { imgAlignment === 'right' }
+							variant   = { imgAlignment === 'right' ? 'primary' : undefined }
 							onClick   = { () => { updateimgAlignment( 'right' ) } }
 						>
 							<Dashicon icon = 'align-right'/>

--- a/src/components/search-modal/search-modal.tsx
+++ b/src/components/search-modal/search-modal.tsx
@@ -307,7 +307,7 @@ const SearchBox = (props: SearchBoxProps) => {
                 className = 'bottom-controls'
             >
                 <Button
-                    isSecondary
+                    variant     = 'secondary'
                     className   = 'cancel-button'
                     onClick     = { close }
                 >
@@ -413,7 +413,7 @@ const SearchButton = (props: SearchButtonProps) => {
 
   return (
     <>
-      <Button isSecondary onClick={openModal}>
+      <Button variant="secondary" onClick={openModal}>
         {children}
       </Button>
       {isOpen && (


### PR DESCRIPTION
Closes the last of the deprecated `@wordpress/components` usage tracked in #146.

`isPrimary`/`isSecondary` have been deprecated since 5.4 in favour of `variant`, and `IconButton` in favour of `Button` with an `icon` prop. Both still work — nothing here fixes a bug — but `IconButton` logs a deprecation warning on every render, and its type resolves acceptable props to `never`, which forced an `as any` compat shim in `ImageSelector`.

- All 24 `isPrimary`/`isSecondary` call sites across 10 files now pass `variant`.
- `ImageSelector`'s two `IconButton`s are `Button`s with `icon`; the shim and its `NOTE(wp-types)` are gone.
- In `ImageSizePanel` the prop was conditional (`isPrimary={ imgAlignment === 'left' }`), so it became `variant={ cond ? 'primary' : undefined }` — `undefined` renders the same default button that `isPrimary={false}` did.

No rendered markup changes: `Button` maps the deprecated props onto `variant` internally, so the emitted `is-primary`/`is-secondary` classes are identical.

## Verification

- `npm run typecheck` clean, `npm run build` succeeds, all unit tests pass.
- e2e: this branch matches `main`'s pre-existing failures. The suite has unreliable cross-spec state today (`cat-id-autogen` fails identically on `main`); no failure is attributable to this change.

## Not included

`ColorPicker` in `collection-main-navigation` still holds an `as any`. It is not a pure cast removal — the modern component has no `disabled` prop and takes `onChange(string)` rather than the legacy `onChangeComplete(obj.hex)` — so it needs a UX decision and is tracked separately in #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)