### PR TITLE
Fix the pre-existing bugs and null dereferences the TypeScript migration preserved

### DIFF
--- a/museum-remote/src/collection-block/edit.tsx
+++ b/museum-remote/src/collection-block/edit.tsx
@@ -49,14 +49,8 @@ const RemoteCollectionSearchBox = ( props: RemoteCollectionSearchBoxProps ) => {
 		wpmRestBase
 	} = props;
 
-	// TODO(ts-migration): SearchBox sometimes invokes fetchSearchResults with
-	// only two arguments (see FetchSearchResults in search-modal.tsx); this
-	// implementation unconditionally calls updateLastRefresh, so those calls
-	// throw at runtime. Pre-existing bug preserved.
-	const fetchSearchResults = ( searchText: string | null, onlyTitle: boolean, updateLastRefresh?: ( refreshTime: Date ) => void, updateResults?: ( results: Collection[] ) => void ) => {
-		// TODO(strict): possible undefined at runtime — two-argument calls from
-		// SearchBox reach here without updateLastRefresh (pre-existing bug above).
-		updateLastRefresh!( new Date() );
+	const fetchSearchResults = ( searchText: string | null, onlyTitle: boolean, updateLastRefresh: ( refreshTime: Date ) => void, updateResults: ( results: Collection[] ) => void ) => {
+		updateLastRefresh( new Date() );
 		let fetchURL = `${remoteData.url}${wpmRestBase}/collections?uuid=${remoteData.uuid}`;
 		if ( onlyTitle ) {
 			fetchURL += `&post_title=${searchText}`;
@@ -68,8 +62,7 @@ const RemoteCollectionSearchBox = ( props: RemoteCollectionSearchBoxProps ) => {
 				console.log( response.statusText );
 				return;
 			}
-			// TODO(strict): possible undefined at runtime — see updateLastRefresh above.
-			response.json().then( data => updateResults!( data ) );
+			response.json().then( data => updateResults( data ) );
 		} );
 	}
 

--- a/src/admin-react/src/oai-pmh/index.tsx
+++ b/src/admin-react/src/oai-pmh/index.tsx
@@ -177,6 +177,17 @@ const DublinCoreFieldMapping = ({
   );
 };
 
+/**
+ * The string form of a kind's id, as used for the selector value and for
+ * matching the selected kind. `kind_id` is the database primary key and is
+ * always present on kinds returned by the REST API — the wire type allows
+ * null only because an unsaved `ObjectKind` has no id yet. Such a kind gets
+ * the empty string, which matches no selection, instead of crashing on
+ * `null.toString()`.
+ */
+const kindIdString = (kind: Pick<ObjectKind, "kind_id">): string =>
+  kind.kind_id === null ? "" : String(kind.kind_id);
+
 interface KindSelectorProps {
   kinds: ObjectKind[];
   selectedKind: string;
@@ -194,7 +205,7 @@ const KindSelector = ({ kinds, selectedKind, onKindChange }: KindSelectorProps) 
       >
         <option value="">-- Select Kind --</option>
         {kinds.map((kind) => (
-          <option key={kind.kind_id} value={kind.kind_id as number}>
+          <option key={kind.kind_id} value={kindIdString(kind)}>
             {kind.label || kind.name}
           </option>
         ))}
@@ -235,8 +246,7 @@ const OmiPmhAdmin = () => {
 
         // Auto-select the first kind if available
         if (kindsData && kindsData.length > 0) {
-          // TODO(strict): possible null at runtime if kind_id is unset
-          setSelectedKind(kindsData[0].kind_id!.toString());
+          setSelectedKind(kindIdString(kindsData[0]));
         }
       } catch (err) {
         setError("Failed to load kinds: " + (err as Error).message);
@@ -279,10 +289,7 @@ const OmiPmhAdmin = () => {
       const fetchKindData = async () => {
         try {
           // Find the selected kind object
-          // TODO(strict): possible null at runtime if kind_id is unset
-          const kind = kinds.find(
-            (k) => k.kind_id!.toString() === selectedKind,
-          );
+          const kind = kinds.find((k) => kindIdString(k) === selectedKind);
           if (!kind) {
             throw new Error("Selected kind not found");
           }
@@ -415,8 +422,7 @@ const OmiPmhAdmin = () => {
 
     try {
       // Find the selected kind object
-      // TODO(strict): possible null at runtime if kind_id is unset
-      const kind = kinds.find((k) => k.kind_id!.toString() === selectedKind);
+      const kind = kinds.find((k) => kindIdString(k) === selectedKind);
       if (!kind) {
         throw new Error("Selected kind not found");
       }
@@ -440,8 +446,7 @@ const OmiPmhAdmin = () => {
       // Update local kinds state
       setKinds((prevKinds) =>
         prevKinds.map((k) =>
-          // TODO(strict): possible null at runtime if kind_id is unset
-          k.kind_id!.toString() === selectedKind
+          kindIdString(k) === selectedKind
             ? {
                 ...k,
                 oai_pmh_mappings: {

--- a/src/admin-react/src/objects/edit.tsx
+++ b/src/admin-react/src/objects/edit.tsx
@@ -116,10 +116,10 @@ const Edit = (props: EditProps) => {
   });
 
   const refreshFieldData = useCallback(() => {
-    // TODO(ts-migration): pre-existing bug — comparing against the string
-    // literal "null", but the wire value of type_name is string | JSON null,
-    // never the string "null". Preserved as-is (no behavior change).
-    if (!kindPostType || kindPostType === "null") {
+    // `type_name` is a `string` in the kinds schema, so an unset one comes
+    // back as JSON null (never the string "null") — a kind that has not been
+    // saved yet has no post type to fetch fields for.
+    if (!kindPostType) {
       return;
     }
 
@@ -218,6 +218,12 @@ const Edit = (props: EditProps) => {
     fieldItem: string,
     changeEventOrValue: any,
   ) => {
+    // Every caller comes from a row rendered out of `fieldData`, so the
+    // edited field is loaded and present; skip rather than dereference a
+    // field that is not.
+    const currentField = fieldData?.[fieldId];
+    if (!currentField) return;
+
     // Handle both event objects and direct values for compatibility
     const newValue =
       changeEventOrValue && changeEventOrValue.target
@@ -230,8 +236,7 @@ const Edit = (props: EditProps) => {
     if (fieldItem.startsWith("dimension")) {
       const newFieldData = Object.assign({}, fieldData);
       const [dimension, key, index] = fieldItem.split(".");
-      // TODO(strict): possible null at runtime if called before fields load
-      const dimensionsField = fieldData![fieldId]["dimensions"];
+      const dimensionsField = currentField["dimensions"];
       const newDimensionData = dimensionsField
         ? dimensionsField
         : dimensionsDefault;
@@ -250,11 +255,9 @@ const Edit = (props: EditProps) => {
 
     // Update field data immediately
     const newFieldData = Object.assign({}, fieldData);
-    // TODO(strict): possible null at runtime if called before fields load
     if (
-      (fieldData![fieldId] as unknown as Record<string, unknown>)[
-        fieldItem
-      ] !== newValue
+      (currentField as unknown as Record<string, unknown>)[fieldItem] !==
+      newValue
     ) {
       (newFieldData[fieldId] as unknown as Record<string, unknown>)[
         fieldItem
@@ -286,10 +289,12 @@ const Edit = (props: EditProps) => {
   };
 
   const updateFactors = (fieldId: number, newFactors: string[]) => {
+    // As in updateField: the row being edited was rendered from `fieldData`.
+    const currentField = fieldData?.[fieldId];
+    if (!currentField) return;
+
     if (
-      // TODO(strict): possible null at runtime if called before fields load
-      JSON.stringify(fieldData![fieldId]["factors"]) !==
-      JSON.stringify(newFactors)
+      JSON.stringify(currentField["factors"]) !== JSON.stringify(newFactors)
     ) {
       const newFieldData = Object.assign({}, fieldData);
       newFieldData[fieldId]["factors"] = newFactors;
@@ -304,8 +309,10 @@ const Edit = (props: EditProps) => {
   ) => {
     if (sourceFieldId === targetFieldId) return;
 
-    // TODO(strict): possible null at runtime if called before fields load
-    const fieldValues = Object.values(fieldData!);
+    // Dragging is only possible between rows rendered from `fieldData`; if
+    // it somehow isn't loaded, the source/target lookups below fail the
+    // existing guard and the drop is a no-op.
+    const fieldValues = Object.values(fieldData ?? {});
     const sourceField = fieldValues.find((f) => f.field_id === sourceFieldId);
     const targetField = fieldValues.find((f) => f.field_id === targetFieldId);
 
@@ -367,11 +374,15 @@ const Edit = (props: EditProps) => {
     setDragOverField(null);
   };
 
-  const defaultFieldData: EditableField = {
+  /**
+   * Template for a newly added field. `kind_id` is deliberately absent: it is
+   * supplied by `addField`, which refuses to add a field to a kind that has
+   * not been saved yet. Every fields request interpolates `type_name` into
+   * its path, so acting on an unsaved kind would address `/null/fields`.
+   */
+  const defaultFieldData: Omit<EditableField, "kind_id"> = {
     field_id: 0,
     slug: "",
-    // TODO(strict): possible null at runtime — wire kind_id is number | null
-    kind_id: kindId as number,
     name: "",
     type: "plain",
     display_order: 0,
@@ -389,8 +400,16 @@ const Edit = (props: EditProps) => {
   };
 
   const addField = async () => {
+    if (!kindPostType || kindId === null) {
+      setFieldsSaveState((prev) => ({
+        ...prev,
+        saveError: "Save this object type before adding fields.",
+      }));
+      return;
+    }
+
     const updatedFieldData = fieldData ? Object.assign({}, fieldData) : {};
-    updatedFieldData[nextFieldId] = { ...defaultFieldData };
+    updatedFieldData[nextFieldId] = { ...defaultFieldData, kind_id: kindId };
     updatedFieldData[nextFieldId]["field_id"] = nextFieldId;
 
     if (fieldData && Object.values(fieldData).length > 0) {

--- a/src/admin-react/src/objects/index.tsx
+++ b/src/admin-react/src/objects/index.tsx
@@ -179,13 +179,20 @@ const ObjectAdminControl = () => {
     }
   }, [objectKinds]);
 
+  // The kind mutation handlers below all need `objectKinds` to have loaded.
+  // The render path guarantees it: `Main` renders no controls at all until
+  // the fetch resolves, `Edit` is only rendered for a `kindItem` picked out
+  // of an already-loaded list, and `objectKinds` is never set back to null
+  // once loaded. Their `if (!objectKinds)` guards are therefore no-ops that
+  // keep that invariant checked rather than asserted away.
+
   const updateKind = (
     kindId: number | null,
     field: string,
     event: { target: { type: string; value: any; checked: any } },
   ) => {
-    // TODO(strict): possible null at runtime if called before kinds load
-    const kinds = objectKinds!;
+    if (!objectKinds) return;
+    const kinds = objectKinds;
     const kindIndex = kinds.findIndex(
       (kindItem) => kindItem.kind_id == kindId,
     );
@@ -215,6 +222,7 @@ const ObjectAdminControl = () => {
   };
 
   const importKind = async (file: File): Promise<boolean> => {
+    if (!objectKinds) return false;
     try {
       const text = await file.text();
       const importedData = JSON.parse(text);
@@ -227,8 +235,7 @@ const ObjectAdminControl = () => {
       kindData.cat_field_id = null;
 
       // Add the new kind to the list
-      // TODO(strict): possible null at runtime if called before kinds load
-      const newObjectKinds = objectKinds!.concat([kindData]);
+      const newObjectKinds = objectKinds.concat([kindData]);
       setObjectKinds(newObjectKinds);
 
       // Save the kind first
@@ -304,34 +311,36 @@ const ObjectAdminControl = () => {
   };
 
   const newKind = () => {
+    if (!objectKinds) return;
+
     // Track existing kind IDs before creating new one
-    // TODO(strict): possible null at runtime if called before kinds load
     const currentKindIds = new Set(
-      objectKinds!
+      objectKinds
         .filter((kind) => kind.kind_id! > 0)
         .map((kind) => kind.kind_id!),
     );
     setExistingKindIds(currentKindIds);
 
     const newKind = Object.assign({}, defaultKind);
-    const newObjectKinds = objectKinds!.concat([newKind]);
+    const newObjectKinds = objectKinds.concat([newKind]);
     setObjectKinds(newObjectKinds);
     setNavigateToNewKind(true);
     saveKindData();
   };
 
   const deleteKind = (kindItem: AdminKind) => {
+    if (!objectKinds) return;
+
     // TODO: Replace with accessible modal dialog for better accessibility
     let confirmDelete = confirm(
       "Really delete this kind? Kinds with associated objects cannot be deleted — delete those objects first.",
     );
     if (confirmDelete) {
-      // TODO(strict): possible null at runtime if called before kinds load
-      const kindIndex = objectKinds!.findIndex(
+      const kindIndex = objectKinds.findIndex(
         (item) => item.kind_id == kindItem.kind_id,
       );
       if (kindIndex !== -1) {
-        const newKindArray = objectKinds!.concat([]);
+        const newKindArray = objectKinds.concat([]);
         newKindArray[kindIndex].delete = true;
         setObjectKinds(newKindArray);
         saveKindData();

--- a/src/blocks/advanced-search/edit.tsx
+++ b/src/blocks/advanced-search/edit.tsx
@@ -41,16 +41,17 @@ interface SearchFieldEntry {
  * AdvancedSearchUI plus the pagination/limit keys added here and by
  * withPagination.
  *
- * TODO(ts-migration): pre-existing bug — the server ignores posts_per_page,
- * selectedFlags, selectedKind, and searchFields (only per_page, page, status,
- * s/searchText, onlyTitle, post_title, post_content, tilde-prefixed field
- * slugs, selectedCollections, and selectedTags are read); shape preserved
- * as-is.
+ * `Objects_Controller::get_items()` (the /search callback) reads per_page,
+ * page, status, s/searchText, onlyTitle, post_title, post_content,
+ * tilde-prefixed field slugs, selectedCollections and selectedTags.
+ *
+ * TODO(ts-migration): `selectedKind` is still ignored by the server; /search
+ * always queries every kind, and there is no request param for restricting it
+ * (the per-kind routes are GET-only). Fixing it needs a server-side change.
  */
 interface AdvancedSearchParams {
   page?: number;
   per_page?: number;
-  posts_per_page?: number;
   searchText?: string;
   onlyTitle?: boolean;
   selectedFlags?: string[];
@@ -106,6 +107,8 @@ const AdvancedSearchEdit = (props: AdvancedSearchEditProps) => {
   );
   const [kindsData, setKindsData] = useState<ObjectKind[]>([]);
   const [searchResults, setSearchResults] = useState<MuseumObject[]>([]);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [totalPages, setTotalPages] = useState<number>(0);
   const [currentSearchParams, setCurrentSearchParams] =
     useState<AdvancedSearchParams>({});
 
@@ -144,18 +147,42 @@ const AdvancedSearchEdit = (props: AdvancedSearchEditProps) => {
         break;
       }
     }
+    // The server reads per-field searches as tilde-prefixed field slugs and
+    // flags as boolean field params; it has never read `searchFields` or
+    // `selectedFlags` themselves. Expand them the same way the front end does,
+    // so the editor preview returns the results the visitor will see.
+    if (searchParams.searchFields?.length) {
+      for (const field of searchParams.searchFields) {
+        if (field.search) {
+          (searchParams as Record<string, unknown>)[field.field as string] =
+            field.search.startsWith("~") ? field.search : `~${field.search}`;
+        }
+      }
+    }
+    if (searchParams.selectedFlags?.length) {
+      for (const flag of searchParams.selectedFlags) {
+        (searchParams as Record<string, unknown>)[flag] = true;
+      }
+    }
     // Use resultsPerPage setting (-1 means unlimited/all results)
-    // TODO(ts-migration): pre-existing bug — the server ignores
-    // `posts_per_page` (only `per_page` is read); preserved as-is.
-    searchParams["posts_per_page"] = resultsPerPage;
+    searchParams["per_page"] = resultsPerPage;
     setCurrentSearchParams(searchParams);
-    apiFetch<MuseumObject[]>({
+    apiFetch({
       path: `${baseRestPath}/search`,
       method: "POST",
       data: searchParams,
-    }).then((result) => {
-      setSearchResults(result);
-    });
+      parse: false,
+    })
+      .then((response) => {
+        setCurrentPage(parseInt(response.headers.get("X-WP-Page") ?? "") || 1);
+        setTotalPages(
+          parseInt(response.headers.get("X-WP-TotalPages") ?? "") || 0,
+        );
+        return response.json();
+      })
+      .then((result: MuseumObject[]) => {
+        setSearchResults(result);
+      });
   };
 
   const blockProps = useBlockProps();
@@ -261,12 +288,8 @@ const AdvancedSearchEdit = (props: AdvancedSearchEditProps) => {
       />
       {searchResults && searchResults.length > 0 && (
         <PaginatedObjectGrid
-          /* TODO(ts-migration): pre-existing bug — `query_data` never exists
-             on the wire (schema-stripped); pagination info actually arrives
-             via X-WP-* headers, so these fall back to 1 / 0. Casts preserve
-             current behavior. */
-          currentPage={(searchResults[0] as any)?.query_data?.current_page || 1}
-          totalPages={(searchResults[0] as any)?.query_data?.num_pages || 0}
+          currentPage={currentPage}
+          totalPages={totalPages}
           searchCallback={onSearch}
           /* NOTE(wp-types): AdvancedSearchParams carries extra keys
              (searchFields, posts_per_page, …) beyond MuseumObjectSearchParams'

--- a/src/blocks/advanced-search/front.tsx
+++ b/src/blocks/advanced-search/front.tsx
@@ -25,16 +25,19 @@ interface SearchFieldEntry {
  * AdvancedSearchUI plus the pagination/limit keys added here and by
  * withPagination.
  *
- * TODO(ts-migration): pre-existing bug — the server ignores posts_per_page,
- * selectedFlags, selectedKind, and searchFields (only per_page, page, status,
- * s/searchText, onlyTitle, post_title, post_content, tilde-prefixed field
- * slugs, selectedCollections, and selectedTags are read); shape preserved
- * as-is.
+ * `Objects_Controller::get_items()` (the /search callback) reads per_page,
+ * page, status, s/searchText, onlyTitle, post_title, post_content,
+ * tilde-prefixed field slugs, selectedCollections and selectedTags.
+ * `selectedFlags` and `searchFields` are not read directly — onSearch below
+ * expands them into the field-slug params the server does read.
+ *
+ * TODO(ts-migration): `selectedKind` is still ignored by the server; /search
+ * always queries every kind, and there is no request param for restricting it
+ * (the per-kind routes are GET-only). Fixing it needs a server-side change.
  */
 interface AdvancedSearchParams {
   page?: number;
   per_page?: number;
-  posts_per_page?: number;
   searchText?: string;
   onlyTitle?: boolean;
   selectedFlags?: string[];
@@ -109,6 +112,8 @@ const AdvancedSearchFront = (props: AdvancedSearchFrontProps) => {
   );
   const [kindsData, setKindsData] = useState<ObjectKind[]>([]);
   const [searchResults, setSearchResults] = useState<MuseumObject[]>([]);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [totalPages, setTotalPages] = useState<number>(0);
   // NOTE(wp-types): the initial state is an empty ARRAY that is then
   // treated as a params object; cast preserves the existing literal.
   const [currentSearchParams, setCurrentSearchParams] =
@@ -178,6 +183,10 @@ const AdvancedSearchFront = (props: AdvancedSearchFrontProps) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
+        setCurrentPage(parseInt(response.headers.get("X-WP-Page") ?? "") || 1);
+        setTotalPages(
+          parseInt(response.headers.get("X-WP-TotalPages") ?? "") || 0,
+        );
         return response.json();
       })
       .then((data) => {
@@ -186,21 +195,10 @@ const AdvancedSearchFront = (props: AdvancedSearchFrontProps) => {
       .catch((error) => {
         console.error("Search request failed:", error);
         setSearchResults([]); // Reset to empty state on error
+        setCurrentPage(1);
+        setTotalPages(0);
       });
   };
-
-  let currentPage = 1;
-  let totalPages = 0;
-  // TODO(ts-migration): pre-existing bug — `query_data` never exists on the
-  // wire (schema-stripped); pagination info actually arrives via X-WP-*
-  // headers, so this branch never runs. Casts preserve current behavior.
-  if (
-    searchResults.length > 0 &&
-    typeof (searchResults[0] as any).query_data !== "undefined"
-  ) {
-    currentPage = (searchResults[0] as any).query_data.current_page;
-    totalPages = (searchResults[0] as any).query_data.num_pages;
-  }
 
   return (
     <>

--- a/src/blocks/basic-search/edit.tsx
+++ b/src/blocks/basic-search/edit.tsx
@@ -21,7 +21,7 @@ import {
 
 import apiFetch from '@wordpress/api-fetch';
 
-import type { ComponentType, ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -47,13 +47,6 @@ interface BasicSearchEditProps {
 	setAttributes: ( attributes: Partial<BasicSearchAttributes> ) => void;
 }
 
-// TODO(ts-migration): pre-existing prop mismatch — PaginatedObjectList expects
-// `mObjects` plus pagination props (currentPage, totalPages, searchCallback,
-// searchParams), but this block passes `objects`, `displayImages`, and
-// `columns`, so the list receives undefined mObjects and renders nothing.
-// Cast preserves current behavior.
-const UntypedPaginatedObjectList = PaginatedObjectList as ComponentType<any>;
-
 /**
  * Basic search of the catalogue.
  *
@@ -77,6 +70,8 @@ const BasicSearchEdit = ( props: BasicSearchEditProps ) => {
 	} = attributes;
 
 	const [ searchResults, setSearchResults ] = useState<MuseumObject[]>( [] );
+	const [ currentPage, setCurrentPage ] = useState<number>( 1 );
+	const [ totalPages, setTotalPages ] = useState<number>( 0 );
 	const [ currentSearchParams, setCurrentSearchParams ] =
 		useState<MuseumObjectSearchParams>( {} );
 
@@ -87,14 +82,26 @@ const BasicSearchEdit = ( props: BasicSearchEditProps ) => {
 				break;
 			}
 		}
+		searchParams['per_page'] = resultsPerPage;
 		setCurrentSearchParams( searchParams );
-		apiFetch<MuseumObject[]>( {
+		apiFetch( {
 			path:   `${baseRestPath}/search`,
 			method: 'POST',
-			data:   searchParams
-		} ).then( result => {
-			setSearchResults( result );
-		} );
+			data:   searchParams,
+			parse:  false
+		} )
+			.then( response => {
+				setCurrentPage(
+					parseInt( response.headers.get( 'X-WP-Page' ) ?? '' ) || 1
+				);
+				setTotalPages(
+					parseInt( response.headers.get( 'X-WP-TotalPages' ) ?? '' ) || 0
+				);
+				return response.json();
+			} )
+			.then( ( result: MuseumObject[] ) => {
+				setSearchResults( result );
+			} );
 	}
 
 	return (
@@ -156,10 +163,13 @@ const BasicSearchEdit = ( props: BasicSearchEditProps ) => {
 				</a>
 			}
 			{ searchResults &&
-				<UntypedPaginatedObjectList
-					objects       = { searchResults }
-					displayImages = { true }
-					columns       = { columns }
+				<PaginatedObjectList
+					currentPage    = { currentPage }
+					totalPages     = { totalPages }
+					searchCallback = { onSearch }
+					searchParams   = { currentSearchParams }
+					mObjects       = { searchResults }
+					displayImages  = { true }
 				/>
 			}
 		</div>

--- a/src/blocks/basic-search/front.tsx
+++ b/src/blocks/basic-search/front.tsx
@@ -46,6 +46,8 @@ const BasicSearchFront = (props: BasicSearchFrontProps) => {
   const [currentSearchParams, setCurrentSearchParams] =
     useState<MuseumObjectSearchParams>([] as unknown as MuseumObjectSearchParams);
   const [searchResults, setSearchResults] = useState<MuseumObject[]>([]);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [totalPages, setTotalPages] = useState<number>(0);
   const [currentSearchText, setCurrentSearchText] = useState(searchText);
 
   const onSearch = (searchParams: MuseumObjectSearchParams) => {
@@ -55,19 +57,35 @@ const BasicSearchFront = (props: BasicSearchFrontProps) => {
         break;
       }
     }
-    // TODO(ts-migration): pre-existing bug — the server ignores `numberposts`
-    // (only per_page, page, etc. are read); preserved as-is.
-    searchParams["numberposts"] = resultsPerPage;
+    searchParams["per_page"] = resultsPerPage;
+    // withPagination mutates and re-submits the object it is handed as
+    // `searchParams`, so the searched params have to become the current ones —
+    // otherwise paging re-submits the mount-time object (empty searchText) and
+    // blanks the results. Matches advanced-search/front.tsx.
+    setCurrentSearchParams(searchParams);
     if (searchParams["searchText"]) {
-      apiFetch<MuseumObject[]>({
+      apiFetch({
         path: `${baseRestPath}/search`,
         method: "POST",
         data: searchParams,
-      }).then((result) => {
-        setSearchResults(result);
-      });
+        parse: false,
+      })
+        .then((response) => {
+          setCurrentPage(
+            parseInt(response.headers.get("X-WP-Page") ?? "") || 1,
+          );
+          setTotalPages(
+            parseInt(response.headers.get("X-WP-TotalPages") ?? "") || 0,
+          );
+          return response.json();
+        })
+        .then((result: MuseumObject[]) => {
+          setSearchResults(result);
+        });
     } else {
       setSearchResults([]);
+      setCurrentPage(1);
+      setTotalPages(0);
     }
   };
 
@@ -87,19 +105,6 @@ const BasicSearchFront = (props: BasicSearchFrontProps) => {
       });
     }
   }, []);
-
-  let currentPage = 1;
-  let totalPages = 0;
-  // TODO(ts-migration): pre-existing bug — `query_data` never exists on the
-  // wire (schema-stripped); pagination info actually arrives via X-WP-*
-  // headers, so this branch never runs. Casts preserve current behavior.
-  if (
-    searchResults.length > 0 &&
-    typeof (searchResults[0] as any).query_data != "undefined"
-  ) {
-    currentPage = (searchResults[0] as any).query_data.current_page;
-    totalPages = (searchResults[0] as any).query_data.num_pages;
-  }
 
   return (
     <div className="wpm-basic-search-block">
@@ -144,10 +149,11 @@ const basicSearchElements = document.getElementsByClassName(
 if (!!basicSearchElements) {
   for (let i = 0; i < basicSearchElements.length; i++) {
     const basicSearchElement = basicSearchElements[i] as HTMLElement;
-    // TODO(strict): dataset.attributes may be undefined at runtime if the
-    // data attribute is missing; cast preserves existing behavior.
+    // The data attribute is missing (or empty) if render.php could not encode
+    // the block attributes; fall back to an empty set so the block still
+    // mounts with its defaults rather than throwing out of JSON.parse.
     const attributes = attributesFromJSON(
-      basicSearchElement.dataset.attributes as string,
+      basicSearchElement.dataset.attributes || "{}",
     ) as BasicSearchFrontAttributes;
     const root = createRoot(basicSearchElement);
     root.render(<BasicSearchFront attributes={attributes} />);

--- a/src/blocks/child-objects/edit.tsx
+++ b/src/blocks/child-objects/edit.tsx
@@ -138,27 +138,44 @@ const ChildObjectsEdit = ( props: ChildObjectsEditProps ) => {
 
 	const deleteChildObject = ( child: MuseumObject, kind: ObjectKindChild ) => {
 		if ( ! childObjects ) return;
-		const updatedChildObjects: Record<string, number[]> = Object.assign( {}, childObjects );
+		// The attribute holds plain post IDs (see the child_objects meta schema
+		// in class-objectposttype.php). `child` is museum-shaped (`ID`) when it
+		// came from the REST refresh, but is still the WP core create response
+		// (`id`) when it was added in this editing session.
+		const childRecord = child as unknown as { ID?: number; id?: number };
+		const childId = childRecord.ID ?? childRecord.id;
+		if ( ! childId ) return;
+
 		// NOTE(wp-types): kind_id is number | null on the wire; asserted to
 		// preserve the existing index behavior.
-		if ( typeof updatedChildObjects[ kind.kind_id as number ] === 'undefined' ) {
-			return;
+		const kindId = kind.kind_id as number;
+		const updatedChildObjects: Record<string, number[]> = Object.assign( {}, childObjects );
+		const kindObjects = updatedChildObjects[ kindId ];
+		const index = Array.isArray( kindObjects ) ?
+			kindObjects.findIndex( objectId => objectId === childId ) :
+			-1;
+		if ( index !== -1 ) {
+			// Object.assign only shallow-copies, so the per-kind array is still
+			// the one held in the current attribute value — copy it before
+			// splicing rather than mutating the attribute in place.
+			updatedChildObjects[ kindId ] = kindObjects.filter(
+				( _objectId, objectIndex ) => objectIndex !== index
+			);
+			setAttributes( {
+				childObjects : updatedChildObjects,
+				childObjectsStr : JSON.stringify( updatedChildObjects )
+			} );
 		}
-		// TODO(ts-migration): mixes shapes — the array elements are numeric
-		// post IDs (no `.id` property) and `child` is museum-shaped (uppercase
-		// `ID`, no `.id`), so this compares undefined === undefined and always
-		// matches index 0. Pre-existing behavior preserved.
-		const index = updatedChildObjects[ kind.kind_id as number ].findIndex( object => ( object as any ).id === ( child as any ).id );
-		if ( index === -1 ) return;
-		updatedChildObjects[ kind.kind_id as number ].splice( index, 1 );
-		setAttributes( {
-			childObjects : updatedChildObjects,
-			childObjectsStr : JSON.stringify( updatedChildObjects )
-		} );
+
+		// The object is deleted whether or not the attribute knew about it: a
+		// bookkeeping mismatch must not leave the user unable to remove a
+		// child they can see.
 		apiFetch( {
-			path    :  `${wordpressRestPath}/${kind.type_name}/${child.ID}`,
+			path    :  `${wordpressRestPath}/${kind.type_name}/${childId}`,
 			method  : 'DELETE'
-		} ).then( result => console.log(result) );
+		} ).catch( error => {
+			console.error( `Failed to delete child object ${childId}`, error );
+		} );
 	}
 
 	const updateChildObject = ( child: MuseumObject, kind: ObjectKindChild, data: { title: string } ) => {
@@ -173,32 +190,15 @@ const ChildObjectsEdit = ( props: ChildObjectsEditProps ) => {
 		const {
 			type_name,
 			label,
-			block_template
-		// TODO(ts-migration): `block_template` is never present on child kinds
-		// on the wire (schema-stripped server-side), so this template-insertion
-		// path always operates on undefined. Asserted here to preserve the
-		// existing behavior.
-		} = kind as ObjectKindChild & {
-			block_template?: [ string, Record<string, unknown>? ][];
-		};
+		} = kind;
 
-		let postContent = '';
-		if ( block_template ) {
-			block_template.forEach( templateItem => {
-				postContent += '<!-- wp:' + templateItem[0];
-				if ( templateItem.length > 1 ) {
-					postContent += ' {'
-					// NOTE(wp-types): the tuple's second element is optional; the
-					// length check above guarantees it exists here.
-					Object.entries( templateItem[1] as Record<string, unknown> ).forEach( ( [ key, value ] ) => {
-						postContent += `"${key}": "${value}", `
-					} );
-					postContent = postContent.slice(0, -2 );
-					postContent += '}';
-				}
-				postContent += " /-->\n\n"
-			} );
-		}
+		// New children are created with empty content. This used to serialize
+		// the kind's `block_template` into the post content, but child kinds are
+		// serialized with ObjectKind::to_array() (class-objectkind.php), which
+		// has no `block_template` key — and the Kinds_Controller schema strips
+		// it from full kinds too — so that code could never run. Restoring it
+		// requires putting block_template on the wire first.
+		const postContent = '';
 
 		apiFetch<WPCorePostResponse>( {
 			path: `${wordpressRestPath}/${type_name}/`,

--- a/src/blocks/collection-objects/collection-options.tsx
+++ b/src/blocks/collection-objects/collection-options.tsx
@@ -127,23 +127,18 @@ const CollectionSettingsPanel = (props: CollectionSettingsPanelProps) => {
           />
         </>
       )}
-      {/* TODO(ts-migration): RadioControl types expect string option values / selected; these boolean values (and the string comparison in onChange) are pre-existing behavior, preserved unchanged. */}
       <RadioControl
         label="Collection Display"
         help={
           "Should the collection objects and description be " +
           "displayed as a single page or separately with a toggle?"
         }
-        selected={singlePage as any}
-        options={
-          [
-            { label: "Single Page", value: true },
-            { label: "Toggle", value: false },
-          ] as any
-        }
-        onChange={(val) =>
-          updateMeta("single_page", val === "true" ? true : false)
-        }
+        selected={singlePage ? "true" : "false"}
+        options={[
+          { label: "Single Page", value: "true" },
+          { label: "Toggle", value: "false" },
+        ]}
+        onChange={(val) => updateMeta("single_page", val === "true")}
       />
     </PluginDocumentSettingPanelUntyped>
   );

--- a/src/blocks/collection-objects/front.tsx
+++ b/src/blocks/collection-objects/front.tsx
@@ -95,9 +95,14 @@ const collectionObjectsBlockElements = document.getElementsByClassName('wpm-coll
 if ( !! collectionObjectsBlockElements ) {
 	for ( let i = 0; i < collectionObjectsBlockElements.length; i++ ) {
 		const collectionObjectsBlockElement = collectionObjectsBlockElements[i] as HTMLElement;
-		// TODO(strict): dataset values may be undefined at runtime
-		const postID = parseInt( collectionObjectsBlockElement.dataset.postId as string );
-		const parsedResultsPerPage = parseInt( collectionObjectsBlockElement.dataset.resultsPerPage as string );
+		const postID = parseInt( collectionObjectsBlockElement.dataset.postId ?? '' );
+		if ( ! Number.isFinite( postID ) ) {
+			// Without a post ID there is no collection to search, so leave the
+			// block's container untouched rather than mounting a search that
+			// cannot resolve.
+			continue;
+		}
+		const parsedResultsPerPage = parseInt( collectionObjectsBlockElement.dataset.resultsPerPage ?? '' );
 		const resultsPerPage = Number.isFinite( parsedResultsPerPage ) ? parsedResultsPerPage : 20;
 		const root = createRoot( collectionObjectsBlockElement );
 		root.render (

--- a/src/blocks/collection/edit.tsx
+++ b/src/blocks/collection/edit.tsx
@@ -125,11 +125,12 @@ const Collection = (props: CollectionProps) => {
         apiFetch<MuseumObject[]>({ path: objectsRestPath }).then((result) => {
           if (Array.isArray(result) && result.length > 0) {
             const newCollectionObjects: CollectionObjectData[] = result.map((result) => {
-              // TODO(strict): possible null at runtime
-              const objImgURL =
-                result["thumbnail"]!.length > 0
-                  ? (result["thumbnail"]![0] as string)
-                  : null;
+              // thumbnail is `[]` when the object has no image and null when
+              // the src lookup failed.
+              const objThumbnail = result["thumbnail"];
+              const objImgURL = Array.isArray(objThumbnail)
+                ? (objThumbnail[0] ?? null)
+                : null;
               return {
                 imgURL: objImgURL,
                 title: result["post_title"],

--- a/src/blocks/embedded-search/front.tsx
+++ b/src/blocks/embedded-search/front.tsx
@@ -53,8 +53,10 @@ const embeddedSearchElements = document.getElementsByClassName('wpm-embedded-sea
 if ( !! embeddedSearchElements ) {
 	for ( let i = 0; i < embeddedSearchElements.length; i++ ) {
 		const embeddedElement = embeddedSearchElements[i] as HTMLElement;
-		// TODO(strict): dataset value may be undefined at runtime
-		const attributes = attributesFromJSON( embeddedElement.dataset.attributes as string ) as unknown as EmbeddedSearchBlockAttributes;
+		// The data attribute is missing (or empty) if render.php could not
+		// encode the block attributes; fall back to an empty set so the block
+		// still mounts with its defaults rather than throwing out of JSON.parse.
+		const attributes = attributesFromJSON( embeddedElement.dataset.attributes || '{}' ) as unknown as EmbeddedSearchBlockAttributes;
 		const root = createRoot( embeddedElement );
 		root.render (
 			<EmbeddedSearchFront

--- a/src/blocks/feature-collection-widget/edit.tsx
+++ b/src/blocks/feature-collection-widget/edit.tsx
@@ -79,16 +79,20 @@ const FeaturedCollectionEdit = ( props: FeaturedCollectionEditProps ) => {
 	// Array.isArray() is therefore only true for the empty case, so
 	// collectionBoxes is always empty. Pre-existing bug preserved via type
 	// assertion.
+	//
+	// Iterating the object's keys is NOT a fix on its own: those keys are
+	// wpm_collection_tax TERM ids, while FeaturedCollection fetches
+	// /collections/{id}, which takes a collection POST id and does not even
+	// check the post type (Collections_Controller::get_post). Feeding it term
+	// ids would render arbitrary posts as featured collections. The REST layer
+	// has to expose the collection post id (or a term -> post lookup) first.
 	if ( ! isEmpty( objectData ) && Array.isArray( objectData.collections ) ) {
 		collectionBoxes = ( objectData.collections as unknown as number[] ).map( collectionID =>
-			// TODO(ts-migration): FeaturedCollection expects a `showImage` prop,
-			// but the spread attributes only provide `showFeatureImage`, so
-			// showImage is always undefined. Pre-existing behavior preserved;
-			// cast keeps the missing required prop compiling.
 			<FeaturedCollection
-				{ ...( attributes as any ) }
-				key          = { collectionID }
-				collectionID = { collectionID }
+				key             = { collectionID }
+				collectionID    = { collectionID }
+				showImage       = { showFeatureImage }
+				showDescription = { showDescription }
 			/>
 		);
 	}

--- a/src/blocks/object-image-attachments/edit.tsx
+++ b/src/blocks/object-image-attachments/edit.tsx
@@ -114,11 +114,14 @@ const ObjectImageAttachmentEdit = ( props: ObjectImageAttachmentEditProps ) => {
 	} );
 
 	const updateImgData = ( imgId: number, title: string, caption: string, description: string, alt: string ) => {
-		// TODO(strict): possible null at runtime
-		imgData![imgId].title       = title;
-		imgData![imgId].caption     = caption;
-		imgData![imgId].description = description;
-		imgData![imgId].alt         = alt;
+		const itemData = imgData?.[ imgId ];
+		if ( ! itemData ) {
+			return;
+		}
+		itemData.title       = title;
+		itemData.caption     = caption;
+		itemData.description = description;
+		itemData.alt         = alt;
 	}
 
 	const updateImgAttach = ( updatedImgAttach: number[] ) => {
@@ -176,9 +179,16 @@ const ObjectImageAttachmentEdit = ( props: ObjectImageAttachmentEditProps ) => {
 		}
 		imgAttach[ imgIndex ] = imgAttach[ newIndex ];
 		imgAttach[ newIndex ] = imgId;
-		// TODO(strict): possible null at runtime
-		imgData![ imgId ].sort_order = newIndex;
-		imgData![ otherId ].sort_order = imgIndex;
+		// Image data may not have loaded (or may not contain a record for one
+		// of the swapped attachments); the attribute reorder still stands.
+		const movedItem = imgData?.[ imgId ];
+		const otherItem = imgData?.[ otherId ];
+		if ( movedItem ) {
+			movedItem.sort_order = newIndex;
+		}
+		if ( otherItem ) {
+			otherItem.sort_order = imgIndex;
+		}
 
 		const updatedImgAttach = ( Array.isArray(imgAttach) ? [ ...imgAttach ] : [] );
 		setAttributes( {

--- a/src/blocks/object-infobox/edit.tsx
+++ b/src/blocks/object-infobox/edit.tsx
@@ -268,13 +268,20 @@ const ObjectInfoEdit = (props: ObjectInfoEditProps) => {
 
         // Format content based on field type
         let content: MuseumObjectFieldValue = "";
-        // TODO(ts-migration): 'tinyint' is not a real field type (the boolean
-        // type is 'flag') and flag values arrive as JSON booleans, not 1, so
-        // this branch never matches. Preserved as-is; the cast keeps the
-        // no-overlap comparison compiling.
-        if ((fieldsMetadata[key]["type"] as string) === "tinyint") {
+        // Boolean fields have type 'flag' and arrive as JSON booleans. (The
+        // type used to be stored as 'tinyint' with a 1/0 value; see
+        // translate_field_types() in database-upgrade.php.)
+        if (fieldsMetadata[key]["type"] === "flag") {
+          // Only map a value that is actually present: a flag that was never
+          // set stays empty so info-content's "Unknown" normalization still
+          // applies, rather than asserting "No".
+          const flagValue = objectData[fieldsMetadata[key]["slug"]];
           content =
-            objectData[fieldsMetadata[key]["slug"]] === 1 ? "Yes" : "No";
+            flagValue === undefined || flagValue === null
+              ? ""
+              : flagValue
+                ? "Yes"
+                : "No";
         } else {
           content = objectData[
             fieldsMetadata[key]["slug"]
@@ -402,8 +409,6 @@ const ObjectInfoEdit = (props: ObjectInfoEditProps) => {
     displayImage,
     linkToObject,
     totalImages,
-    imgHeight,
-    imgWidth,
     imgIndex,
   } = attributes;
 
@@ -447,8 +452,6 @@ const ObjectInfoEdit = (props: ObjectInfoEditProps) => {
         excerpt={displayExcerpt ? excerpt : null}
         imgIndex={imgIndex}
         imgURL={imgURL}
-        imgHeight={imgHeight}
-        imgWidth={imgWidth}
         displayImage={displayImage}
         objectURL={linkToObject ? objectURL : null}
         fields={fields}

--- a/src/blocks/object-infobox/info-content.tsx
+++ b/src/blocks/object-infobox/info-content.tsx
@@ -13,12 +13,6 @@ import { useState } from "@wordpress/element";
 import { hexToRgb } from "../../javascript/util";
 import { ObjectSearchBox, ImageSelector } from "../../components";
 
-// TODO(ts-migration): this block has always passed imgHeight/imgWidth to
-// ImageSelector, which ImageSelectorProps does not declare (the component
-// ignores them at runtime). Cast to keep the currently-working call site
-// unchanged.
-const ImageSelectorCompat = ImageSelector as any;
-
 import type { ElementType, ReactNode } from "react";
 
 import type {
@@ -44,8 +38,6 @@ interface InfoContentProps {
   excerpt: string | null;
   imgURL: string | null;
   imgIndex: number;
-  imgHeight: number;
-  imgWidth: number;
   displayImage: boolean;
   fields: Record<string, boolean>;
   fieldData: Record<string, InfoboxFieldData>;
@@ -72,8 +64,6 @@ const InfoContent = (props: InfoContentProps) => {
     excerpt,
     imgURL,
     imgIndex,
-    imgHeight,
-    imgWidth,
     displayImage,
     fields,
     fieldData,
@@ -139,9 +129,7 @@ const InfoContent = (props: InfoContentProps) => {
       {displayImage && (
         <div className={`infobox-img-wrapper`}>
           {objectID ? (
-            <ImageSelectorCompat
-              imgHeight={imgHeight}
-              imgWidth={imgWidth}
+            <ImageSelector
               objectID={objectID}
               imgIndex={imgIndex}
               imgURL={imgURL}

--- a/src/blocks/object-meta/edit.tsx
+++ b/src/blocks/object-meta/edit.tsx
@@ -134,19 +134,21 @@ const ObjectMetaField = (props: ObjectMetaFieldProps) => {
       />
     );
   } else if (fieldType == "measure") {
-    // TODO(strict): possible null at runtime — dimensions is
-    // FieldDimensions | null on the wire; asserted to preserve behavior.
-    if (fieldData.dimensions!.n == 1) {
+    // `dimensions` is null on the wire when the stored JSON was malformed.
+    // Fall back to a single unlabeled measurement rather than throwing while
+    // rendering the block.
+    const dimensions = fieldData.dimensions;
+    if (!dimensions || !dimensions.n || dimensions.n == 1) {
       inputElement = (
         <input
           name={fieldSlug}
           type="number"
-          value={fieldValue[0]}
+          value={fieldValue?.[0] ?? ""}
           onChange={(event) => onMeasureChange(event, 0)}
         />
       );
     } else {
-      const dimensionElements = fieldData.dimensions!.labels.map(
+      const dimensionElements = dimensions.labels.map(
         (dimensionLabel, index) => (
           <label key={index}>
             <div className="input-element-dimension-label">
@@ -155,7 +157,7 @@ const ObjectMetaField = (props: ObjectMetaFieldProps) => {
             <input
               name={fieldSlug}
               type="number"
-              value={fieldValue[index]}
+              value={fieldValue?.[index] ?? ""}
               onChange={(event) => onMeasureChange(event, index)}
             />
           </label>
@@ -199,6 +201,45 @@ const ObjectMetaField = (props: ObjectMetaFieldProps) => {
       <div className="errorMessage">{errorText}</div>
     </div>
   );
+};
+
+/**
+ * Validates a single field's current value.
+ *
+ * Returns the message to display beneath the field, or null when the field is
+ * fine. Only emptiness of a required field is enforced: the `field_schema`
+ * check below is deliberately inert (see the commented-out assignment), it is
+ * kept so the intended rule is not lost.
+ *
+ * @param fieldData  The field definition, as returned by
+ *                   GET /wp-museum/v1/{type}/fields.
+ * @param fieldValue The field's current value in the block's attributes.
+ */
+export const getFieldError = (
+  fieldData: MObjectField,
+  fieldValue: any,
+): ReactNode => {
+  const { field_schema: fieldSchema, required } = fieldData;
+
+  if (required && !fieldValue) {
+    return <span>Field is required but empty.</span>;
+  }
+
+  if (fieldSchema) {
+    // field_schema is a regex typed by hand in the admin UI, so it may not
+    // compile. Guarded because nothing here is worth breaking the editor over.
+    try {
+      const pattern = "^" + stripslashes(fieldSchema) + "$";
+      const regex = new RegExp(pattern);
+      if (!regex.test(fieldValue)) {
+        //return ( <span>Value does not conform to schema.</span> );
+      }
+    } catch (error) {
+      // Invalid pattern stored for the field — nothing to report.
+    }
+  }
+
+  return null;
 };
 
 interface ObjectMetaEditProps {
@@ -273,30 +314,20 @@ const ObjectMetaEdit = (props: ObjectMetaEditProps) => {
     setAttributes(setObject);
   };
 
-  const checkField = (fieldData: MObjectField) => {
-    const {
-      slug: fieldSlug,
-      field_schema: fieldSchema,
-      name: fieldName,
-      required,
-    } = fieldData;
-
-    const updatedFieldErrors = Object.assign({}, fieldErrors);
-
-    // clear existing errors
-    updatedFieldErrors[fieldSlug] = null;
+  const checkField = (fieldData: MObjectField, skipEmpty = false) => {
+    const { slug: fieldSlug, name: fieldName, required } = fieldData;
 
     const fieldValue = attributes[fieldSlug];
 
-    if (required && !fieldValue) {
-      updatedFieldErrors[fieldSlug] = <span>Field is required but empty.</span>;
-    } else if (fieldSchema) {
-      const pattern = "^" + stripslashes(fieldSchema) + "$";
-      const regex = new RegExp(pattern);
-      if (!regex.test(fieldValue)) {
-        //updatedFieldErrors[ fieldSlug ] = ( <span>Value does not conform to schema.</span> );
-      }
-    }
+    // Functional update so that checking every field in a loop does not drop
+    // the errors set for the other fields.
+    setFieldErrors((currentErrors) => ({
+      ...currentErrors,
+      [fieldSlug]:
+        skipEmpty && !fieldValue
+          ? null
+          : getFieldError(fieldData, fieldValue),
+    }));
 
     // Check to make sure catalogue ID field is unique.
     if (postData && fieldValue && postData.cat_field === fieldSlug) {
@@ -305,13 +336,11 @@ const ObjectMetaEdit = (props: ObjectMetaEditProps) => {
         path: `${baseRestPath}/all?${fieldSlug}=${fieldValue}`,
       }).then(
         (result) => {
-          const updatedFieldErrors = Object.assign({}, fieldErrors);
-          let foundError = false;
+          let duplicateError: ReactNode = null;
           if (Array.isArray(result) && result.length > 0) {
             result.map((objectData) => {
               if (objectData.ID != postId) {
-                foundError = true;
-                updatedFieldErrors[fieldSlug] = (
+                duplicateError = (
                   <span>
                     {`${fieldName} must be unique, but is already used by `}
                     {/* NOTE(wp-types): edit_link is string | null on the wire;
@@ -324,8 +353,11 @@ const ObjectMetaEdit = (props: ObjectMetaEditProps) => {
                 );
               }
             });
-            if (foundError) {
-              setFieldErrors(updatedFieldErrors);
+            if (duplicateError) {
+              setFieldErrors((currentErrors) => ({
+                ...currentErrors,
+                [fieldSlug]: duplicateError,
+              }));
             } else {
               if (!catFieldIsGood) setCatFieldIsGood(true);
             }
@@ -333,27 +365,29 @@ const ObjectMetaEdit = (props: ObjectMetaEditProps) => {
         },
       );
     }
-    setFieldErrors(updatedFieldErrors);
   };
 
-  const checkAllFields = () => {
+  const checkAllFields = (skipEmpty = false) => {
     // Non-null assertion: only called from the effect below after the
-    // `!!fieldData` guard.
-    Object.entries(fieldData!).map((field) => {
-      // TODO(ts-migration): pre-existing bug — Object.entries yields
-      // [key, value] tuples, but checkField expects the field object itself,
-      // so every destructured property (slug, field_schema, name, required)
-      // is undefined here and the checks are no-ops. Cast preserves the
-      // current behavior.
-      checkField(field as unknown as MObjectField);
+    // `!!fieldData` guard. Object.values, not Object.entries — checkField
+    // takes the field itself, not a [ field_id, field ] tuple.
+    Object.values(fieldData!).map((field) => {
+      checkField(field, skipEmpty);
     });
   };
 
+  // These checks were inert until #147 — checkAllFields passed
+  // Object.entries tuples to a function expecting the field itself, so every
+  // check read undefined. Now that they run, the load-time pass skips empty
+  // fields on a new object: flagging every required field before the curator
+  // has typed anything is noise, not validation. postData is a dependency
+  // because the catalogue-uniqueness check below needs it, and it does not
+  // necessarily arrive before fieldData.
   useEffect(() => {
     if (!!fieldData && !isEmpty(fieldData)) {
-      checkAllFields();
+      checkAllFields(currentPostStatus === "auto-draft");
     }
-  }, [fieldData]);
+  }, [fieldData, postData, currentPostStatus]);
 
   // Override Gutenberg's Tab handling so keyboard navigation moves through
   // the object edit sequence — post title, description paragraph(s), then
@@ -418,11 +452,14 @@ const ObjectMetaEdit = (props: ObjectMetaEditProps) => {
       const range = doc.createRange();
       range.selectNodeContents(el);
       range.collapse(false);
-      // TODO(strict): possible null at runtime — defaultView/getSelection
-      // can be null per the DOM types; asserted to preserve behavior.
-      const selection = doc.defaultView!.getSelection();
-      selection!.removeAllRanges();
-      selection!.addRange(range);
+      // Either can be null (a detached document has no defaultView, and
+      // getSelection() returns null when the document is not rendered). The
+      // element has already been focused, so leaving the caret where the
+      // browser put it is the right fallback.
+      const selection = doc.defaultView?.getSelection();
+      if (!selection) return;
+      selection.removeAllRanges();
+      selection.addRange(range);
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/blocks/object-meta/front.tsx
+++ b/src/blocks/object-meta/front.tsx
@@ -8,9 +8,14 @@ const objectImageGalleryElements = document.getElementsByClassName('wpm-objectpo
 if ( !! objectImageGalleryElements ) {
 	for ( let i = 0; i < objectImageGalleryElements.length; i++ ) {
 		const objectImageGalleryElement = objectImageGalleryElements[i] as HTMLElement;
-		// TODO(strict): dataset.postId may be undefined at runtime if the data
-		// attribute is missing (parseInt would yield NaN); cast preserves behavior.
-		const postId = parseInt( objectImageGalleryElement.dataset.postId as string );
+		// data-post-ID is written by object-meta/render.php, but the container
+		// can also be hand-written into a template. Without a usable post id
+		// the gallery has nothing to fetch, so leave the element alone.
+		const postIdAttribute = objectImageGalleryElement.dataset.postId;
+		const postId = postIdAttribute ? parseInt( postIdAttribute, 10 ) : NaN;
+		if ( Number.isNaN( postId ) ) {
+			continue;
+		}
 		const root = createRoot( objectImageGalleryElement );
 		root.render (
 			<ObjectPostImageGallery

--- a/src/components/advanced-search-ui/advanced-search-ui.tsx
+++ b/src/components/advanced-search-ui/advanced-search-ui.tsx
@@ -23,8 +23,9 @@ interface SearchFieldEntry {
  * Search values managed by AdvancedSearchUI.
  *
  * `selectedKind` is a number when seeded from kindsData or parsed from the
- * URL, but a string once the user picks a kind in the SelectControl (see the
- * TODO(ts-migration) note on the kind lookup below).
+ * URL, but a string once the user picks a kind in the SelectControl (whose
+ * onChange always yields a string), so consumers must normalise before
+ * comparing it against `kind_id`.
  */
 interface AdvancedSearchValues {
   searchText?: string;
@@ -88,14 +89,20 @@ const FieldSearchElement = (props: FieldSearchElementProps) => {
 
   let inputElement;
   if (type === "date") {
-    let searchVals;
+    // `search` is null until something is typed into the field (and
+    // JSON.parse( null ) returns null rather than throwing), so fall back to
+    // an empty date range for anything that is not a parsed JSON object.
+    let searchVals: { fromDate?: string; toDate?: string } = {};
 
-    try {
-      // TODO(strict): search may be null/undefined at runtime; JSON.parse
-      // failures are caught below, so the cast preserves existing behavior.
-      searchVals = JSON.parse(search as string);
-    } catch {
-      searchVals = {};
+    if (typeof search === "string" && search !== "") {
+      try {
+        const parsedSearch = JSON.parse(search);
+        if (!!parsedSearch && typeof parsedSearch === "object") {
+          searchVals = parsedSearch;
+        }
+      } catch {
+        // Not valid JSON: keep the empty date range.
+      }
     }
 
     const { fromDate, toDate } = searchVals;
@@ -290,18 +297,24 @@ const AdvancedSearchUI = (props: AdvancedSearchUIProps) => {
       !!kindsData &&
       kindsData.length > 0
     ) {
-      // TODO(ts-migration): pre-existing bug — selectedKind is a string once
-      // the user picks a kind in the SelectControl, while kind_id is a number,
-      // so this strict comparison never matches after user selection.
-      // Preserved as-is.
+      // kind_id is an integer in the REST schema, while selectedKind is a
+      // string whenever it comes from the SelectControl (or from a
+      // defaultSearch that was saved after the user picked a kind), so
+      // compare the numeric values.
+      const selectedKindId =
+        typeof selectedKind === "string"
+          ? parseInt(selectedKind, 10)
+          : selectedKind;
       const selectedKindData = kindsData.find(
-        (kindItem) => kindItem.kind_id === selectedKind,
+        (kindItem) => kindItem.kind_id === selectedKindId,
       );
-      // TODO(strict): possible null at runtime — see TODO(ts-migration) above;
-      // find() can return undefined and type_name can be null.
-      getFieldData(selectedKindData!.type_name!).then((result) =>
-        setFieldData(result),
-      );
+      // No matching kind (or a kind with no post type): leave the current
+      // field data in place rather than fetching fields for nothing.
+      if (!!selectedKindData && !!selectedKindData.type_name) {
+        getFieldData(selectedKindData.type_name).then((result) =>
+          setFieldData(result),
+        );
+      }
     }
   }, [selectedKind, kindsData]);
 
@@ -419,16 +432,16 @@ const AdvancedSearchUI = (props: AdvancedSearchUIProps) => {
           >
             Reset Search
           </Button>
-          <Button
-            variant="secondary"
-            onClick={() =>
-              // TODO(strict): possible undefined at runtime if inEditor is set
-              // without setAttributes; preserved as-is.
-              setAttributes!({ defaultSearch: JSON.stringify(searchValues) })
-            }
-          >
-            Set Defaults
-          </Button>
+          {!!setAttributes && (
+            <Button
+              variant="secondary"
+              onClick={() =>
+                setAttributes({ defaultSearch: JSON.stringify(searchValues) })
+              }
+            >
+              Set Defaults
+            </Button>
+          )}
         </div>
       )}
       <div

--- a/src/components/featured-collection/featured-collection.tsx
+++ b/src/components/featured-collection/featured-collection.tsx
@@ -37,10 +37,7 @@ const FeaturedCollection = ( props: FeaturedCollectionProps ) => {
 				<img
 					className = 'wpm-featured-collection-image'
 					src       = { collectionData.featured_image[0] }
-					// TODO(ts-migration): `title` never exists on the wire (only
-					// `post_title`), so the fallback string is always used —
-					// pre-existing bug preserved via type assertion.
-					alt       = { ( collectionData as { title?: string } ).title || 'Featured collection' }
+					alt       = { collectionData.post_title || 'Featured collection' }
 				/>
 			}
 			<h2>

--- a/src/components/object-editor-table/object-editor-table.tsx
+++ b/src/components/object-editor-table/object-editor-table.tsx
@@ -1,4 +1,20 @@
+import { __ } from '@wordpress/i18n';
+
 import type { MuseumObject } from '../../types';
+
+/**
+ * `post_status_label` is computed server-side but stripped by the REST
+ * schema, so the label has to be derived from the slug here. Anything not
+ * listed (a custom status) falls back to the slug itself.
+ */
+const POST_STATUS_LABELS: Record<string, string> = {
+	publish : __( 'Published' ),
+	draft   : __( 'Draft' ),
+	pending : __( 'Pending Review' ),
+	private : __( 'Private' ),
+	future  : __( 'Scheduled' ),
+	trash   : __( 'Trash' ),
+};
 
 interface ObjectEditorTableRowProps {
 	mObject: MuseumObject;
@@ -13,18 +29,15 @@ const ObjectEditorTableRow = ( props: ObjectEditorTableRowProps ) => {
 		link,
 		edit_link         : editLink,
 		post_title        : postTitle,
-		// TODO(ts-migration): post_status_label is stripped by the REST
-		// schema and never exists on the wire — always undefined. Preserving
-		// existing (buggy) behavior.
-		post_status_label : postStatus
-	} = mObject as MuseumObject & { post_status_label?: string };
+		post_status       : postStatus
+	} = mObject;
 
 	return (
 		<tr>
 			<th scope="row">{ postTitle }</th>
 			<td><a href = { editLink as string } aria-label={`Edit ${postTitle}`}>Edit</a></td>
 			<td><a href = { link } aria-label={`View ${postTitle}`}>View</a></td>
-			<td>{ postStatus }</td>
+			<td>{ POST_STATUS_LABELS[ postStatus ] ?? postStatus }</td>
 		</tr>
 	);
 }

--- a/src/components/object-grid/object-grid.tsx
+++ b/src/components/object-grid/object-grid.tsx
@@ -192,15 +192,16 @@ const ObjectGridBoxDynamicImage = (props: ObjectGridBoxDynamicImageProps) => {
               : null
         }
       />
+      {/* imgData may still be null here (the modal can open before the image
+          fetch resolves) or empty for an object with no images; ObjectModal
+          renders the entry without a gallery in both cases. */}
       {doObjectModal && modalOpen && (
         <ObjectModal
           title={decodedPostTitle}
           content={excerpt}
           url={link}
           linkText="View full entry"
-          // TODO(strict): possible null at runtime — modal can open before the
-          // image fetch resolves; ObjectModal would then crash on Object.values.
-          images={imgData!}
+          images={imgData}
           close={() => setModalOpen(false)}
         />
       )}

--- a/src/components/object-image-grid/object-image-grid.tsx
+++ b/src/components/object-image-grid/object-image-grid.tsx
@@ -55,25 +55,34 @@ const ObjectImageBox = (props: ObjectImageBoxProps) => {
     width: 300,
   };
 
-  // TODO(strict): possible null at runtime — imgData may be an empty object,
-  // in which case getFirstObjectImage returns null and getBestImage crashes.
-  const bestImage = getBestImage(getFirstObjectImage(imgData)!, imgDimensions);
+  const firstImage = getFirstObjectImage(imgData);
+  const bestImage = firstImage ? getBestImage(firstImage, imgDimensions) : null;
 
-  // TODO(ts-migration): title/alt are read on the whole images map (keyed by
-  // attachment ID), not on an individual image record — always undefined, so
-  // these fall through to "". Preserving existing (buggy) behavior.
+  // Objects with no attached images (or whose image sizes all failed to
+  // resolve) get the same placeholder as objects whose images haven't loaded.
+  if (!firstImage || !bestImage || bestImage.URL === null) {
+    return (
+      <div className="grid-image-wrapper" style={imgStyle}>
+        <div className="placeholder-box"></div>
+      </div>
+    );
+  }
+
   const imgAttrs = {
-    src: bestImage.URL as string,
-    title: (imgData as any).title || "",
-    alt: (imgData as any).alt || "",
+    src: bestImage.URL,
+    title: firstImage.title || "",
+    alt: firstImage.alt || "",
   };
 
   return (
     <div className="grid-image-wrapper" style={imgStyle}>
       <MaybeLink href={object.URL} doLink={linkToObjects}>
-        {/* TODO(strict): possible undefined at runtime — onClickCallback is an
-            optional prop; clicking with no callback provided would crash. */}
-        <img {...imgAttrs} onClick={() => onClickCallback!(object.ID) || null} />
+        <img
+          {...imgAttrs}
+          onClick={
+            onClickCallback ? () => onClickCallback(object.ID) : undefined
+          }
+        />
       </MaybeLink>
     </div>
   );

--- a/src/components/object-list/object-list.tsx
+++ b/src/components/object-list/object-list.tsx
@@ -1,4 +1,4 @@
-import type { ImageSizeTuple, MuseumObject } from '../../types';
+import type { MuseumObject } from '../../types';
 
 import withPagination from '../with-pagination/with-pagination';
 
@@ -24,17 +24,20 @@ const ObjectRow = ( props: ObjectRowProps ) => {
 
 	const decodedPostTitle = decodeHtmlEntities( post_title );
 
+	// thumbnail is `[]` for an object with no image, and null when the src
+	// lookup failed; either way there is nothing to display.
+	const thumbnailURL =
+		Array.isArray( thumbnail ) && thumbnail.length > 0 ? thumbnail[ 0 ] : null;
+
 	return (
 		<div className = 'object-row'>
 			<a href = { link }><h2>{ post_title }</h2></a>
 			<div className = 'object-row-content'>
 				{ displayImage &&
 					<div className = 'object-row-image'>
-						{ /* TODO(strict): thumbnail can be `[]` or null on the wire
-						   (object without an image); the cast preserves the existing
-						   unguarded index access, which yields an undefined src for
-						   `[]` and throws for null. Tracked in #126. */ }
-						<a href = { link }><img src={( thumbnail as ImageSizeTuple )[0]} alt={decodedPostTitle} /></a>
+						{ !! thumbnailURL &&
+							<a href = { link }><img src={ thumbnailURL } alt={decodedPostTitle} /></a>
+						}
 					</div>
 				}
 				<div className = 'object-info'>

--- a/src/components/object-modal/object-modal.tsx
+++ b/src/components/object-modal/object-modal.tsx
@@ -20,7 +20,12 @@ import type { ObjectImage, ObjectImagesResponse } from '../../types';
 
 
 interface ImageScrollProps {
-	images: ObjectImagesResponse;
+	/**
+	 * The object's images, or null while the fetch is still pending. An
+	 * object with no attached images arrives as an empty array (see
+	 * EmptyPhpArray), so neither case can be assumed away.
+	 */
+	images: ObjectImagesResponse | null;
 }
 
 const ImageScroll = ( props: ImageScrollProps ) => {
@@ -28,7 +33,7 @@ const ImageScroll = ( props: ImageScrollProps ) => {
 		images
 	} = props;
 
-	const imgArray: ObjectImage[] = Object.values( images );
+	const imgArray: ObjectImage[] = !! images ? Object.values( images ) : [];
 	imgArray.sort( (a, b) => a['sort_order'] - b['sort_order'] );
 
 	const [ imgIndex, setImgIndex ] = useState( 0 );
@@ -51,6 +56,18 @@ const ImageScroll = ( props: ImageScrollProps ) => {
 		setImgIndex( targetIndex );
 	}
 
+	// Nothing to scroll through: the images are still loading, or the object
+	// has none. The modal's title, excerpt and link are still worth showing,
+	// so render the frame without an image rather than refusing to open.
+	if ( imgArray.length === 0 ) {
+		return (
+			<div
+				className  = 'object-modal-image-scroll'
+				aria-label = 'Image gallery showing 0 images'
+			/>
+		);
+	}
+
 	const bestImage = getBestImage( imgArray[ imgIndex ], imgDimensions );
 
 	return (
@@ -70,11 +87,13 @@ const ImageScroll = ( props: ImageScrollProps ) => {
 				onClick   = { () => updateImgIndex( 1 ) }
 			/>
 			<div className = 'img-wrapper' aria-live='polite' aria-atomic='true'>
-				<img
-					src   = { bestImage.URL as string }
-					title = { imgArray[imgIndex].title || '' }
-					alt   = { imgArray[imgIndex].alt || imgArray[imgIndex].title || 'Museum object image' }
-				/>
+				{ !! bestImage.URL &&
+					<img
+						src   = { bestImage.URL }
+						title = { imgArray[imgIndex].title || '' }
+						alt   = { imgArray[imgIndex].alt || imgArray[imgIndex].title || 'Museum object image' }
+					/>
+				}
 			</div>
 		</div>
 	);
@@ -85,7 +104,7 @@ interface ObjectModalProps {
 	content: ReactNode;
 	url: string;
 	linkText: ReactNode;
-	images: ObjectImagesResponse;
+	images: ObjectImagesResponse | null;
 	close: () => void;
 }
 

--- a/src/components/object-post-image-gallery/object-post-image-gallery.tsx
+++ b/src/components/object-post-image-gallery/object-post-image-gallery.tsx
@@ -46,11 +46,9 @@ const ObjectPostImageSideBox = ( props: ObjectPostImageSideBoxProps ) => {
 
 	return (
 		<div className = 'wpm_obj-image'>
-			{ !! imgData &&
+			{ !! bestImage?.URL &&
 				<img
-					// Non-null: bestImage is computed whenever imgData is
-					// truthy, which the surrounding guard ensures.
-					src     = { bestImage!.URL as string }
+					src     = { bestImage.URL }
 					alt     = { altText }
 					title   = { titleText }
 					onClick = { () => openModal( imgIndex ) }
@@ -82,12 +80,18 @@ const ObjectPostImageModal = ( props: ObjectPostImageModalProps ) => {
 	const imgArray = Object.values( imgData )
 		.sort( (a, b ) => a['sort_order'] - b['sort_order'] );
 
+	const currentImage = imgArray[ imgIndex ];
+
 	const {
 		title       = null,
 		caption     = null,
 		description = null,
 		alt         = null,
-	} = imgArray[ imgIndex ];
+	} = currentImage;
+
+	// 'full' is null on the wire when the src lookup fails for that size.
+	const fullSize    = currentImage[ 'full' ];
+	const fullSizeURL = Array.isArray( fullSize ) ? fullSize[ 0 ] : null;
 
 	const imgDimensions = {
 		height: 1024,
@@ -125,16 +129,16 @@ const ObjectPostImageModal = ( props: ObjectPostImageModalProps ) => {
 							/>
 						}
 					</div>
-					<div className = 'image-modal-image-link'>
-						<a
-							// TODO(strict): possible null at runtime — 'full'
-							// can be null on the wire (see ImageSizeTuple).
-							href = { imgArray[ imgIndex ]['full']![0] }
-							target = '_blank'
-						>
-							View Full Image
-						</a>
-					</div>
+					{ !! fullSizeURL &&
+						<div className = 'image-modal-image-link'>
+							<a
+								href = { fullSizeURL }
+								target = '_blank'
+							>
+								View Full Image
+							</a>
+						</div>
+					}
 					{ displayCaption &&
 						<div className = 'image-modal-caption'>
 							{ caption }
@@ -164,10 +168,7 @@ const ObjectPostImageGallery = ( props: ObjectPostImageGalleryProps ) => {
 	const [ modalOpen, setModalOpen ] = useState( false );
 	const [ imgIndex, setImgIndex ] = useState( 0 );
 
-	// TODO(ts-migration): pre-existing quirk — updateImgData is invoked with
-	// postId below but never took a parameter (it closes over postId);
-	// optional unused param keeps the call site unchanged.
-	const updateImgData = ( _postId?: number ) => {
+	const updateImgData = () => {
 		fetchObjectImages( postId ).then( images => setImgData( images as ObjectImagesResponse ) );
 	}
 
@@ -192,7 +193,7 @@ const ObjectPostImageGallery = ( props: ObjectPostImageGalleryProps ) => {
 
 	useEffect( () => {
 		if ( !! postId ) {
-			updateImgData( postId );
+			updateImgData();
 		}
 	}, [ postId ] );
 

--- a/src/components/search-modal/search-modal.tsx
+++ b/src/components/search-modal/search-modal.tsx
@@ -41,17 +41,14 @@ type SearchReturnCallback = (postId: number | null) => void;
 /**
  * Callback to fetch results for the search.
  *
- * TODO(ts-migration): updateLastRefresh/updateResults are typed optional
- * because SearchBox invokes this with only two arguments in the delayed
- * (setTimeout) path and in onTitleToggle, while both existing implementations
- * unconditionally call updateLastRefresh(new Date()) — those two-argument
- * calls throw a TypeError at runtime. Pre-existing bug preserved.
+ * Every implementation dereferences updateLastRefresh and updateResults, so
+ * all four arguments are required and every call site passes them.
  */
 type FetchSearchResults = (
-  searchText: string | null,
+  searchText: string,
   onlyTitle: boolean,
-  updateLastRefresh?: (refreshTime: Date) => void,
-  updateResults?: (results: SearchResult[]) => void,
+  updateLastRefresh: (refreshTime: Date) => void,
+  updateResults: (results: SearchResult[]) => void,
 ) => void;
 
 /**
@@ -174,7 +171,8 @@ const SearchBox = (props: SearchBoxProps) => {
       } else {
         setTimerId(
           setTimeout(
-            () => fetchSearchResults(content, onlyTitle),
+            () =>
+              fetchSearchResults(content, onlyTitle, setLastRefresh, setResults),
             refreshInterval -
               ((currentTime as unknown as number) -
                 (lastRefresh as unknown as number)),
@@ -190,8 +188,24 @@ const SearchBox = (props: SearchBoxProps) => {
   const onTitleToggle = () => {
     setOnlyTitle(!onlyTitle);
     setSelectedItem(0);
-    fetchSearchResults(searchText, !onlyTitle);
+    // Same threshold as onChangeSearchText: below it there is nothing worth
+    // searching for, and the previous results stay on screen.
+    if (searchText !== null && searchText.length > 2) {
+      fetchSearchResults(searchText, !onlyTitle, setLastRefresh, setResults);
+    }
   };
+
+  // The debounced search used to be dead (it called fetchSearchResults with
+  // two arguments, which threw). Now that it fires, a pending timer has to be
+  // cancelled when the box goes away, or it resolves against an unmounted
+  // component.
+  useEffect(() => {
+    return () => {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+      }
+    };
+  }, [timerId]);
 
   /**
    * Callback to capture keypresses from the search input for navigating the
@@ -480,10 +494,7 @@ const ObjectSearchBox = (props: ObjectSearchBoxProps) => {
     <SearchBox
       close={close}
       title={title}
-      // TODO(strict): see TODO(ts-migration) on FetchSearchResults — the
-      // implementation requires args that SearchBox sometimes omits
-      // (pre-existing runtime bug preserved); cast is type-only.
-      fetchSearchResults={fetchSearchResults as FetchSearchResults}
+      fetchSearchResults={fetchSearchResults}
       returnCallback={returnCallback}
     />
   );
@@ -538,10 +549,7 @@ const CollectionSearchBox = (props: CollectionSearchBoxProps) => {
     <SearchBox
       close={close}
       title={title}
-      // TODO(strict): see TODO(ts-migration) on FetchSearchResults — the
-      // implementation requires args that SearchBox sometimes omits
-      // (pre-existing runtime bug preserved); cast is type-only.
-      fetchSearchResults={fetchSearchResults as FetchSearchResults}
+      fetchSearchResults={fetchSearchResults}
       returnCallback={returnCallback}
     />
   );

--- a/src/javascript/util.tsx
+++ b/src/javascript/util.tsx
@@ -4,7 +4,6 @@ import type { ReactNode, MouseEventHandler } from "react";
 
 import type {
 	Collection,
-	ImageSizeTuple,
 	ObjectImage,
 	ObjectImagesResponse,
 } from "../types";
@@ -53,6 +52,14 @@ export interface BestFitImage {
 	width: number;
 }
 
+/**
+ * Finds the smallest available image size at least as large as the requested
+ * dimensions, falling back to the full-size image.
+ *
+ * Size tuples arrive from `wp_get_attachment_image_src()` as
+ * `[url, width, height, isResized]` (see ImageSizeTuple). If no size fits and
+ * the full size is unavailable, URL is null and the dimensions are 0.
+ */
 export function getBestImage( imgData: ObjectImage, imgDimensions: { height: number; width: number } ): BestFitImage {
 	const bestFitImage: BestFitImage = {
 		'URL'    : null,
@@ -65,15 +72,11 @@ export function getBestImage( imgData: ObjectImage, imgDimensions: { height: num
 			continue;
 		}
 
-		// TODO(ts-migration): the wire tuple order is [url, width, height,
-		// isResized] (see ImageSizeTuple), but this destructuring transposes
-		// width/height. Pre-existing bug preserved for zero behavior change.
 		let [
 			URL,
-			height,
 			width,
-			isIntermediate
-		] = dataArray as ImageSizeTuple;
+			height
+		] = dataArray;
 
 		if ( height >= imgDimensions.height &&
 			 height <  bestFitImage.height &&
@@ -87,18 +90,20 @@ export function getBestImage( imgData: ObjectImage, imgDimensions: { height: num
 	}
 
 	if ( bestFitImage.URL === null ) {
-		// TODO(ts-migration): same width/height transposition as above; also
-		// imgData['full'] can be null on the wire, so the cast preserves the
-		// existing (crash-prone) runtime behavior.
-		const [
-			URL,
-			height,
-			width,
-			isIntermediate
-		] = imgData['full'] as ImageSizeTuple;
-		bestFitImage.URL    = URL;
-		bestFitImage.height = height;
-		bestFitImage.width  = width
+		const fullSize = imgData['full'];
+		if ( Array.isArray( fullSize ) && fullSize.length >= 4 ) {
+			const [
+				URL,
+				width,
+				height
+			] = fullSize;
+			bestFitImage.URL    = URL;
+			bestFitImage.height = height;
+			bestFitImage.width  = width
+		} else {
+			bestFitImage.height = 0;
+			bestFitImage.width  = 0;
+		}
 	}
 
 	return bestFitImage;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -33,9 +33,10 @@ export interface WPRestError {
  * WordPress attachment image tuple, from `wp_get_attachment_image_src()`:
  * `[url, width, height, is_resized]`.
  *
- * NOTE: the wire order is url, WIDTH, HEIGHT, boolean. Several JS consumers
- * (`getBestImage` in `src/javascript/util.js`) destructure it as
- * `[URL, height, width, isIntermediate]` — a pre-existing width/height swap.
+ * NOTE: the wire order is url, WIDTH, HEIGHT, boolean. `getBestImage` in
+ * `src/javascript/util.tsx` used to destructure it as
+ * `[URL, height, width, isIntermediate]`; that swap was fixed in #147, so
+ * destructure in wire order.
  */
 export type ImageSizeTuple = [
 	url: string,

--- a/tests/playwright/basic-search-editor.spec.ts
+++ b/tests/playwright/basic-search-editor.spec.ts
@@ -8,12 +8,13 @@
  *
  *   ReferenceError: currentSearchParams is not defined
  *
- * The block still renders no results — PaginatedObjectList is handed
- * `objects` where it expects `mObjects`, which is the other half of #131 and
- * is not fixed here — so this asserts on the absence of the crash rather than
- * on rendered results.
+ * At the time this was written the block also rendered no results, because
+ * PaginatedObjectList was handed `objects` where it expects `mObjects` (the
+ * other half of #131, since fixed under #147). This test still asserts on the
+ * absence of the crash rather than on rendered results.
  *
  * @see https://github.com/Epistemic-Technology/wp-museum/issues/131
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/147
  */
 
 import { test, expect } from "@playwright/test";

--- a/tests/unit/admin-kinds.test.tsx
+++ b/tests/unit/admin-kinds.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tests for the admin kinds/fields screens' handling of kinds that have no
+ * id yet.
+ *
+ * `ObjectKind.kind_id` is the database primary key, so it is always present
+ * on a kind that came back from the REST API — but the wire type allows null
+ * (an unsaved kind has no id), and both screens used to assume otherwise:
+ *
+ * - objects/edit.tsx built a new field with `kind_id: kindId as number`. An
+ *   unsaved kind also has no `type_name`, and every fields request
+ *   interpolates it into the path, so adding a field addressed
+ *   `/wp-museum/v1/null/fields` instead of being rejected up front.
+ * - oai-pmh/index.tsx auto-selected the first kind with
+ *   `kind_id!.toString()`, which throws a TypeError on a null id.
+ *
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/148
+ */
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import apiFetch from '@wordpress/api-fetch';
+
+import Edit from '../../src/admin-react/src/objects/edit';
+import OaiPmhAdmin from '../../src/admin-react/src/oai-pmh';
+
+import type { ObjectKind } from '../../src/types';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+declare const global: { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+const objectKind = ( overrides: Partial< ObjectKind > = {} ): ObjectKind =>
+	( {
+		kind_id: 5,
+		cat_field_id: null,
+		name: 'thing',
+		type_name: 'wpm_thing',
+		label: 'Thing',
+		label_plural: 'Things',
+		description: null,
+		categorized: false,
+		hierarchical: false,
+		parent_kind_id: null,
+		oai_pmh_mappings: {},
+		available_fields_for_oai_pmh: [],
+		children: [],
+		...overrides,
+	} as unknown as ObjectKind );
+
+const render = async ( element: React.ReactElement ) => {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () => {
+		root.render( element );
+	} );
+	return {
+		container,
+		unmount: () => act( () => root.unmount() ),
+	};
+};
+
+const click = async ( container: HTMLElement, label: string ) => {
+	const button = Array.from( container.querySelectorAll( 'button' ) ).find(
+		( candidate ) => candidate.textContent?.trim() === label
+	);
+	if ( ! button ) {
+		throw new Error( `No button labelled "${ label }"` );
+	}
+	await act( async () => {
+		button.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+	} );
+};
+
+const postCalls = () =>
+	mockedApiFetch.mock.calls
+		.map( ( [ options ] ) => options )
+		.filter( ( options ) => options?.method === 'POST' );
+
+const editProps = {
+	kinds: [],
+	updateKind: () => undefined,
+	saveKindData: () => undefined,
+};
+
+beforeEach( () => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	// jsdom does not implement scrollIntoView, which addField() calls on the
+	// row it just inserted.
+	Element.prototype.scrollIntoView = jest.fn();
+	mockedApiFetch.mockReset();
+	// GET fields responds with no fields; POSTs succeed.
+	mockedApiFetch.mockImplementation( ( options: { method?: string } ) =>
+		Promise.resolve( options?.method === 'POST' ? true : {} )
+	);
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'Edit — adding a field', () => {
+	it( 'stamps the new field with the kind it belongs to', async () => {
+		const { container, unmount } = await render(
+			<Edit kindItem={ objectKind() } { ...editProps } />
+		);
+
+		await click( container, 'Add New Field' );
+
+		expect( postCalls() ).toHaveLength( 1 );
+		const [ post ] = postCalls();
+		expect( post.path ).toBe( '/wp-museum/v1/wpm_thing/fields' );
+		const newFields = Object.values(
+			post.data as Record< string, { kind_id: number } >
+		);
+		expect( newFields ).toHaveLength( 1 );
+		expect( newFields[ 0 ].kind_id ).toBe( 5 );
+
+		await unmount();
+	} );
+
+	it( 'refuses to add a field to a kind that has not been saved yet', async () => {
+		const { container, unmount } = await render(
+			<Edit
+				kindItem={ objectKind( { kind_id: null, type_name: null } ) }
+				{ ...editProps }
+			/>
+		);
+
+		await click( container, 'Add New Field' );
+
+		// Nothing is sent — without a type_name the request would be
+		// addressed to `/null/fields`.
+		expect( postCalls() ).toHaveLength( 0 );
+		expect( container.textContent ).toContain(
+			'Save this object type before adding fields'
+		);
+
+		await unmount();
+	} );
+
+	it( 'does not fetch fields for a kind with no post type', async () => {
+		const { unmount } = await render(
+			<Edit
+				kindItem={ objectKind( { kind_id: null, type_name: null } ) }
+				{ ...editProps }
+			/>
+		);
+
+		expect( mockedApiFetch ).not.toHaveBeenCalled();
+
+		await unmount();
+	} );
+} );
+
+describe( 'OAI-PMH admin — kind selection', () => {
+	it( 'auto-selects the first kind', async () => {
+		mockedApiFetch.mockImplementation( () =>
+			Promise.resolve( [ objectKind( { kind_id: 7 } ) ] )
+		);
+
+		const { container, unmount } = await render( <OaiPmhAdmin /> );
+
+		const select = container.querySelector(
+			'#kind-select'
+		) as HTMLSelectElement;
+		expect( select.value ).toBe( '7' );
+
+		await unmount();
+	} );
+
+	it( 'selects nothing, and does not error, for a kind with no id', async () => {
+		mockedApiFetch.mockImplementation( () =>
+			Promise.resolve( [ objectKind( { kind_id: null } ) ] )
+		);
+
+		const { container, unmount } = await render( <OaiPmhAdmin /> );
+
+		const select = container.querySelector(
+			'#kind-select'
+		) as HTMLSelectElement;
+		expect( select.value ).toBe( '' );
+		expect( container.textContent ).not.toContain( 'Failed to load kinds' );
+
+		await unmount();
+	} );
+} );

--- a/tests/unit/collection-blocks.test.tsx
+++ b/tests/unit/collection-blocks.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Tests for the collection blocks and the object table they render.
+ *
+ * Both cover bugs the TypeScript migration recorded rather than fixed:
+ * the editor table read `post_status_label`, which the objects REST schema
+ * strips, so the Status column was always blank; and the collection display
+ * radio round-tripped its value through mismatched types.
+ *
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/147
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+import ObjectEditorTable from '../../src/components/object-editor-table/object-editor-table';
+
+import type { MuseumObject } from '../../src/types';
+
+const mockEditPost = jest.fn();
+
+jest.mock( '@wordpress/edit-post', () => ( {
+	__esModule: true,
+	PluginDocumentSettingPanel: ( {
+		children,
+	}: {
+		children: React.ReactNode;
+	} ) => <div>{ children }</div>,
+} ) );
+
+// CheckboxControl warns about an upcoming margin change; that deprecation
+// notice would otherwise fail the suite through @wordpress/jest-console.
+jest.mock( '@wordpress/deprecated', () => ( {
+	__esModule: true,
+	default: () => undefined,
+} ) );
+
+let mockPostMeta: Record< string, unknown > = {};
+
+// Only the two hooks the panel uses are replaced. @wordpress/components pulls
+// in real @wordpress/data stores at import time, so everything else has to
+// keep working — and it has to be delegated lazily, because the real module
+// imports itself while loading.
+jest.mock( '@wordpress/data', () => {
+	const overrides: Record< string, unknown > = {
+		useDispatch: () => ( { editPost: mockEditPost } ),
+		useSelect: (
+			mapSelect: ( select: ( store: string ) => unknown ) => unknown
+		) =>
+			mapSelect( ( store: string ) => {
+				if ( store === 'core/editor' ) {
+					return {
+						getCurrentPostType: () => 'wpm_collection',
+						getEditedPostAttribute: () => mockPostMeta,
+					};
+				}
+				return { getEntityRecords: () => [] };
+			} ),
+	};
+
+	return new Proxy(
+		{},
+		{
+			get: ( target, property: string ) =>
+				property in overrides
+					? overrides[ property ]
+					: ( jest.requireActual( '@wordpress/data' ) as Record<
+							string,
+							unknown
+					  > )[ property ],
+		}
+	);
+} );
+
+// eslint-disable-next-line import/first
+import CollectionSettingsPanel from '../../src/blocks/collection-objects/collection-options';
+
+// React 18 only flushes updates quietly once it knows act() is supported.
+( global as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean } )
+	.IS_REACT_ACT_ENVIRONMENT = true;
+
+const museumObject = (
+	overrides: Partial< MuseumObject > & { ID: number }
+): MuseumObject =>
+	( {
+		post_title: 'Untitled',
+		post_author: 1,
+		post_date: '2020-01-01 00:00:00',
+		post_date_gmt: '2020-01-01 00:00:00',
+		post_content: '',
+		excerpt: 'An excerpt.',
+		post_status: 'publish',
+		post_name: 'untitled',
+		post_modified: '2020-01-01 00:00:00',
+		post_modified_gmt: '2020-01-01 00:00:00',
+		post_type: 'wpm_instrument',
+		link: 'https://example.test/objects/1',
+		edit_link: 'https://example.test/wp-admin/post.php?post=1&action=edit',
+		thumbnail: [ 'https://example.test/thumb.jpg', 200, 150, true ],
+		cat_field: null,
+		collections: [],
+		...overrides,
+	} as unknown as MuseumObject );
+
+describe( 'ObjectEditorTable', () => {
+	it( 'shows the status of each object', () => {
+		const markup = renderToStaticMarkup(
+			<ObjectEditorTable
+				mObjects={ [
+					museumObject( { ID: 1, post_title: 'Astrolabe' } ),
+					museumObject( {
+						ID: 2,
+						post_title: 'Orrery',
+						post_status: 'draft',
+					} ),
+				] }
+			/>
+		);
+
+		// post_status_label never reaches the client (the REST schema strips
+		// it), so the slug is mapped to a display label here.
+		expect( markup ).toContain( '<td>Published</td>' );
+		expect( markup ).toContain( '<td>Draft</td>' );
+	} );
+
+	it( 'falls back to the raw slug for an unrecognised status', () => {
+		const markup = renderToStaticMarkup(
+			<ObjectEditorTable
+				mObjects={ [
+					museumObject( {
+						ID: 3,
+						post_title: 'Sextant',
+						post_status: 'wpm_on_loan',
+					} ),
+				] }
+			/>
+		);
+
+		expect( markup ).toContain( '<td>wpm_on_loan</td>' );
+	} );
+} );
+
+describe( 'CollectionSettingsPanel', () => {
+	const renderPanel = ( meta: Record< string, unknown > ) => {
+		mockPostMeta = meta;
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		act( () => root.render( <CollectionSettingsPanel /> ) );
+		return {
+			container,
+			cleanup: () => {
+				act( () => root.unmount() );
+				container.remove();
+			},
+		};
+	};
+
+	const displayRadios = ( container: HTMLElement ) =>
+		Array.from(
+			container.querySelectorAll< HTMLInputElement >(
+				'input[type="radio"]'
+			)
+		);
+
+	beforeEach( () => {
+		mockEditPost.mockClear();
+	} );
+
+	it( 'checks the radio matching the stored single_page meta', () => {
+		const { container, cleanup } = renderPanel( { single_page: true } );
+
+		const [ singlePage, toggle ] = displayRadios( container );
+		expect( singlePage.checked ).toBe( true );
+		expect( toggle.checked ).toBe( false );
+
+		cleanup();
+	} );
+
+	it( 'stores single_page as a boolean when the selection changes', () => {
+		const { container, cleanup } = renderPanel( { single_page: true } );
+
+		const toggle = displayRadios( container )[ 1 ];
+		act( () => {
+			toggle.click();
+		} );
+
+		expect( mockEditPost ).toHaveBeenCalledWith( {
+			meta: { single_page: false },
+		} );
+
+		cleanup();
+	} );
+} );

--- a/tests/unit/featured-collection.test.tsx
+++ b/tests/unit/featured-collection.test.tsx
@@ -12,6 +12,10 @@
  * @see https://github.com/Epistemic-Technology/wp-museum/issues/130
  */
 import { renderToStaticMarkup } from 'react-dom/server';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+import apiFetch from '@wordpress/api-fetch';
 
 import FeaturedCollection from '../../src/components/featured-collection/featured-collection';
 
@@ -19,6 +23,20 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,
 	default: jest.fn( () => new Promise( () => undefined ) ),
 } ) );
+
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+// Tells React 18 that act() is supported here, which keeps it from warning
+// on every state update flushed below.
+( global as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean } )
+	.IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+	mockedApiFetch.mockImplementation(
+		() => new Promise( () => undefined )
+	);
+} );
 
 describe( 'FeaturedCollection', () => {
 	it( 'renders without throwing', () => {
@@ -45,5 +63,75 @@ describe( 'FeaturedCollection', () => {
 		// No data yet, so neither the image nor the description is emitted.
 		expect( markup ).not.toContain( '<img' );
 		expect( markup ).not.toContain( 'wpm-featured-collection-description' );
+	} );
+
+	/**
+	 * The image alt text used to read `title`, which the collections REST
+	 * route never returns (the wire property is `post_title`), so every
+	 * featured image fell back to the generic 'Featured collection' string.
+	 *
+	 * @see https://github.com/Epistemic-Technology/wp-museum/issues/147
+	 */
+	describe( 'featured image alt text', () => {
+		const renderWithCollection = async (
+			collection: Record< string, unknown >
+		) => {
+			// A single stable object: setState bails out on an identical
+			// value, so the dependency-less useEffect does not re-fetch
+			// forever.
+			const response = Promise.resolve( collection );
+			mockedApiFetch.mockImplementation( () => response );
+
+			const container = document.createElement( 'div' );
+			document.body.appendChild( container );
+			const root = createRoot( container );
+
+			await act( async () => {
+				root.render(
+					<FeaturedCollection
+						showImage={ true }
+						showDescription={ true }
+						collectionID={ 7 }
+					/>
+				);
+			} );
+
+			const alt = container
+				.querySelector( 'img.wpm-featured-collection-image' )
+				?.getAttribute( 'alt' );
+
+			act( () => root.unmount() );
+			container.remove();
+
+			return alt;
+		};
+
+		it( "uses the collection's post_title", async () => {
+			const alt = await renderWithCollection( {
+				post_title: 'Fossil Casts',
+				featured_image: [
+					'https://example.test/fossils.jpg',
+					300,
+					200,
+					true,
+				],
+			} );
+
+			expect( alt ).toBe( 'Fossil Casts' );
+		} );
+
+		it( 'falls back to a generic alt when the title is empty', async () => {
+			const alt = await renderWithCollection( {
+				post_title: '',
+				featured_image: [
+					'https://example.test/fossils.jpg',
+					300,
+					200,
+					true,
+				],
+			} );
+
+			expect( alt ).toBe( 'Featured collection' );
+		} );
 	} );
 } );

--- a/tests/unit/image-sizing.test.tsx
+++ b/tests/unit/image-sizing.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for the image-sizing pipeline: picking a size tuple out of a wire
+ * image record, and rendering thumbnails that may not exist.
+ *
+ * Size tuples come from `wp_get_attachment_image_src()` and are ordered
+ * `[url, width, height, isResized]` (see the ImageSizeTuple docblock in
+ * src/types/common.ts and the schema in
+ * src/rest/class-object-image-controller.php). getBestImage used to read them
+ * as `[url, height, width, …]`, which picked the wrong file whenever the
+ * requested dimensions were not square.
+ *
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/147
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/148
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { getBestImage } from '../../src/javascript/util';
+import { ObjectList } from '../../src/components/object-list/object-list';
+
+import type { MuseumObject, ObjectImage } from '../../src/types';
+
+/**
+ * An image record as it arrives on the wire, for a landscape source image.
+ * Intermediate sizes are bounding-box scaled, so they are landscape too.
+ */
+const objectImage = ( sizes: Partial< ObjectImage > ): ObjectImage =>
+	( {
+		title: 'An image',
+		caption: '',
+		description: '',
+		alt: 'Alt text',
+		sort_order: 0,
+		full: null,
+		...sizes,
+	} as ObjectImage );
+
+const museumObject = (
+	overrides: Partial< MuseumObject > & { ID: number }
+): MuseumObject =>
+	( {
+		post_title: 'An object',
+		excerpt: 'An excerpt.',
+		post_type: 'wpm_instrument',
+		link: 'https://example.test/objects/1',
+		edit_link: null,
+		thumbnail: [ 'https://example.test/thumb.jpg', 150, 100, true ],
+		cat_field: null,
+		collections: [],
+		...overrides,
+	} as unknown as MuseumObject );
+
+describe( 'getBestImage', () => {
+	it( 'reads the tuple as [url, width, height]', () => {
+		const imgData = objectImage( {
+			medium: [ 'https://example.test/medium.jpg', 400, 200, true ],
+			large: [ 'https://example.test/large.jpg', 1024, 512, true ],
+			full: [ 'https://example.test/full.jpg', 2000, 1000, false ],
+		} );
+
+		const best = getBestImage( imgData, { height: 200, width: 200 } );
+
+		expect( best.URL ).toBe( 'https://example.test/medium.jpg' );
+		expect( best.width ).toBe( 400 );
+		expect( best.height ).toBe( 200 );
+	} );
+
+	it( 'rejects a size that is wide enough but not tall enough', () => {
+		const imgData = objectImage( {
+			// 400 wide × 200 tall: too short for a 400px-tall request.
+			medium: [ 'https://example.test/medium.jpg', 400, 200, true ],
+			full: [ 'https://example.test/full.jpg', 2000, 1000, false ],
+		} );
+
+		const best = getBestImage( imgData, { height: 400, width: 200 } );
+
+		expect( best.URL ).toBe( 'https://example.test/full.jpg' );
+		expect( best.width ).toBe( 2000 );
+		expect( best.height ).toBe( 1000 );
+	} );
+
+	it( 'falls back to the full size when nothing is large enough', () => {
+		const imgData = objectImage( {
+			thumbnail: [ 'https://example.test/thumb.jpg', 150, 150, true ],
+			full: [ 'https://example.test/full.jpg', 800, 600, false ],
+		} );
+
+		const best = getBestImage( imgData, { height: 1024, width: 1024 } );
+
+		expect( best.URL ).toBe( 'https://example.test/full.jpg' );
+		expect( best.width ).toBe( 800 );
+		expect( best.height ).toBe( 600 );
+	} );
+
+	it( 'returns no URL instead of throwing when the full size is null', () => {
+		const imgData = objectImage( {
+			thumbnail: null,
+			full: null,
+		} );
+
+		const best = getBestImage( imgData, { height: 300, width: 300 } );
+
+		expect( best.URL ).toBeNull();
+		expect( best.width ).toBe( 0 );
+		expect( best.height ).toBe( 0 );
+	} );
+} );
+
+describe( 'ObjectList thumbnails', () => {
+	it( 'renders the thumbnail URL when the object has an image', () => {
+		const markup = renderToStaticMarkup(
+			<ObjectList
+				mObjects={ [ museumObject( { ID: 1 } ) ] }
+				displayImages={ true }
+			/>
+		);
+		expect( markup ).toContain( 'src="https://example.test/thumb.jpg"' );
+	} );
+
+	it( 'renders no image when the object has an empty thumbnail array', () => {
+		const markup = renderToStaticMarkup(
+			<ObjectList
+				mObjects={ [ museumObject( { ID: 1, thumbnail: [] } ) ] }
+				displayImages={ true }
+			/>
+		);
+		expect( markup ).not.toContain( '<img' );
+		expect( markup ).toContain( 'object-row-image' );
+	} );
+
+	it( 'renders no image, and does not throw, when the thumbnail is null', () => {
+		let markup = '';
+		expect( () => {
+			markup = renderToStaticMarkup(
+				<ObjectList
+					mObjects={ [ museumObject( { ID: 1, thumbnail: null } ) ] }
+					displayImages={ true }
+				/>
+			);
+		} ).not.toThrow();
+		expect( markup ).not.toContain( '<img' );
+	} );
+} );

--- a/tests/unit/object-meta-fields.test.tsx
+++ b/tests/unit/object-meta-fields.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Tests for field validation in the object-meta block.
+ *
+ * checkAllFields() iterated Object.entries() of the fields response and passed
+ * each [ field_id, field ] tuple to checkField(), which destructures `slug`,
+ * `required` and `field_schema` off it — so every property was undefined and
+ * no field was ever validated on load. These tests cover the per-field rule
+ * and the fact that every field in the response is now checked.
+ *
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/147
+ */
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ObjectMetaEdit, { getFieldError } from '../../src/blocks/object-meta/edit';
+
+import type { MObjectField } from '../../src/types';
+
+const postId = 12;
+
+const field = ( overrides: Partial< MObjectField > ): MObjectField =>
+	( {
+		field_id: 1,
+		slug: 'a_field',
+		kind_id: 1,
+		name: 'A Field',
+		type: 'plain',
+		display_order: 0,
+		public: true,
+		required: false,
+		quick_browse: false,
+		help_text: '',
+		detailed_instructions: '',
+		public_description: '',
+		field_schema: '',
+		max_length: 0,
+		dimensions: null,
+		units: '',
+		factors: [],
+		...overrides,
+	} as MObjectField );
+
+// The fields the mocked REST endpoint returns, keyed by field_id the way
+// Object_Fields_Controller serializes them.
+const mockFieldsResponse = {
+	'1': field( {
+		field_id: 1,
+		slug: 'accession_number',
+		name: 'Accession Number',
+		required: true,
+	} ),
+	'2': field( {
+		field_id: 2,
+		slug: 'description',
+		name: 'Description',
+		required: false,
+	} ),
+	'3': field( { field_id: 3, slug: 'maker', name: 'Maker', required: true } ),
+};
+
+const mockObjectResponse = {
+	ID: postId,
+	post_title: 'An Object',
+	post_type: 'wpm_instrument',
+	// No catalogue-ID field, so the uniqueness request is not made.
+	cat_field: null,
+};
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn( ( { path }: { path: string } ) => {
+		if ( path.endsWith( '/fields' ) ) {
+			return Promise.resolve( mockFieldsResponse );
+		}
+		if ( path.includes( '/all/' ) ) {
+			return Promise.resolve( mockObjectResponse );
+		}
+		return Promise.resolve( [] );
+	} ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useSelect: ( mapSelect: ( select: ( store: string ) => unknown ) => unknown ) =>
+		mapSelect( () => ( {
+			getCurrentPostType: () => 'wpm_instrument',
+			getCurrentPostId: () => postId,
+			isSavingPost: () => false,
+			getEditedPostAttribute: () => 'draft',
+		} ) ),
+	useDispatch: () => ( {
+		createErrorNotice: jest.fn(),
+		lockPostSaving: jest.fn(),
+		unlockPostSaving: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => {
+	const react = require( 'react' );
+	return {
+		__esModule: true,
+		useBlockProps: () => ( { className: 'object-meta-block' } ),
+		InspectorControls: ( { children }: { children?: unknown } ) =>
+			react.createElement( 'div', null, children ),
+		RichText: ( { value }: { value?: string } ) =>
+			react.createElement( 'div', { contentEditable: true }, value ),
+		__experimentalLinkControl: () => null,
+	};
+} );
+
+jest.mock( '@wordpress/components', () => {
+	const react = require( 'react' );
+	const passthrough =
+		( tag: string ) =>
+		( { children }: { children?: unknown } ) =>
+			react.createElement( tag, null, children );
+	return {
+		__esModule: true,
+		PanelBody: passthrough( 'div' ),
+		Popover: passthrough( 'div' ),
+		Button: passthrough( 'button' ),
+		CheckboxControl: () => react.createElement( 'input', { type: 'checkbox' } ),
+		SelectControl: () => react.createElement( 'select' ),
+		TextControl: () => react.createElement( 'input' ),
+	};
+} );
+
+describe( 'getFieldError', () => {
+	it( 'reports a required field that has no value', () => {
+		const error = getFieldError( field( { required: true } ), '' );
+		expect( error ).not.toBeNull();
+		expect(
+			renderToStaticMarkup( error as React.ReactElement )
+		).toContain( 'Field is required but empty' );
+	} );
+
+	it( 'accepts a required field that has a value', () => {
+		expect( getFieldError( field( { required: true } ), 'A value' ) ).toBeNull();
+	} );
+
+	it( 'accepts an optional field that is empty', () => {
+		expect( getFieldError( field( { required: false } ), '' ) ).toBeNull();
+		expect(
+			getFieldError( field( { required: false } ), undefined )
+		).toBeNull();
+	} );
+
+	it( 'does not throw on a field whose stored schema is not a valid regex', () => {
+		expect( () =>
+			getFieldError( field( { field_schema: '[0-9' } ), 'anything' )
+		).not.toThrow();
+	} );
+} );
+
+describe( 'ObjectMetaEdit field validation on load', () => {
+	let container: HTMLDivElement;
+
+	beforeEach( () => {
+		( global as any ).IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		container.remove();
+	} );
+
+	const rowFor = ( label: string ) =>
+		Array.from(
+			container.querySelectorAll< HTMLElement >( '.object-meta-row' )
+		).find( ( row ) =>
+			row
+				.querySelector( '.object-meta-label' )
+				?.textContent?.startsWith( label )
+		);
+
+	const mount = async ( attributes: Record< string, unknown > ) => {
+		await act( async () => {
+			createRoot( container ).render(
+				<ObjectMetaEdit
+					attributes={ attributes }
+					setAttributes={ () => undefined }
+				/>
+			);
+		} );
+		// Let the fields and object requests resolve.
+		await act( async () => undefined );
+	};
+
+	it( 'flags every required field that is empty, not just the first', async () => {
+		await mount( {
+			accession_number: '',
+			description: '',
+			maker: '',
+		} );
+
+		expect( rowFor( 'Accession Number' )?.textContent ).toContain(
+			'Field is required but empty'
+		);
+		expect( rowFor( 'Maker' )?.textContent ).toContain(
+			'Field is required but empty'
+		);
+	} );
+
+	it( 'leaves optional and filled-in fields alone', async () => {
+		await mount( {
+			accession_number: 'X.1',
+			description: '',
+			maker: 'Negretti & Zambra',
+		} );
+
+		expect( container.textContent ).not.toContain(
+			'Field is required but empty'
+		);
+		expect( container.querySelectorAll( '.has-error' ) ).toHaveLength( 0 );
+	} );
+} );

--- a/tests/unit/search-params.test.ts
+++ b/tests/unit/search-params.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Regression tests for the search blocks' REST parameters and pagination.
+ *
+ * `Objects_Controller::get_items()` (the /search callback) reads `per_page`
+ * for the page size and returns paging in the `X-WP-Page` /
+ * `X-WP-TotalPages` response headers. The blocks used to send
+ * `posts_per_page` / `numberposts` — which only the unused
+ * `do_advanced_search()` helper ever read — and to look for a `query_data`
+ * key on the first result, which the controller never emits. The results per
+ * page setting was therefore inert and pagination controls never appeared.
+ *
+ * The bootstrap tests cover the other half: `data-attributes` is absent when
+ * `wp_json_encode()` fails in render.php, and `JSON.parse( undefined )`
+ * throws, which took the whole view script down with it.
+ *
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/147
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/148
+ */
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+import apiFetch from '@wordpress/api-fetch';
+
+import AdvancedSearchFront from '../../src/blocks/advanced-search/front';
+
+// The mock is kept on globalThis so that the view scripts loaded through
+// jest.isolateModules() below (a fresh module registry re-runs this factory)
+// share the one jest.fn the assertions read.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ( globalThis as Record< string, any > ).__wpmApiFetchMock ??=
+		jest.fn() ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+/** Minimal stand-in for the `parse: false` fetch Response. */
+const restResponse = ( headers: Record< string, string >, body: unknown ) => ( {
+	ok: true,
+	status: 200,
+	headers: {
+		get: ( name: string ) => ( name in headers ? headers[ name ] : null ),
+	},
+	json: () => Promise.resolve( body ),
+} );
+
+interface ApiFetchOptions {
+	path: string;
+	data?: Record< string, unknown >;
+	parse?: boolean;
+}
+
+/** Every /search call apiFetch received, most recent last. */
+const searchCalls = (): ApiFetchOptions[] =>
+	mockApiFetch.mock.calls
+		.map( ( call ) => call[ 0 ] as ApiFetchOptions )
+		.filter( ( options ) => options.path.endsWith( '/search' ) );
+
+let container: HTMLDivElement;
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'advanced search block front end', () => {
+	beforeEach( () => {
+		( globalThis as Record< string, unknown > ).IS_REACT_ACT_ENVIRONMENT =
+			true;
+	} );
+
+	afterEach( () => {
+		delete ( globalThis as Record< string, unknown > )
+			.IS_REACT_ACT_ENVIRONMENT;
+	} );
+
+	const render = async ( searchHeaders: Record< string, string > ) => {
+		mockApiFetch.mockImplementation( ( options: ApiFetchOptions ) => {
+			if ( options.path.endsWith( '/search' ) ) {
+				return Promise.resolve( restResponse( searchHeaders, [] ) );
+			}
+			// /collections and /mobject_kinds.
+			return Promise.resolve( [] );
+		} );
+
+		await act( async () => {
+			createRoot( container ).render(
+				createElement( AdvancedSearchFront, {
+					attributes: {
+						fixSearch: true,
+						runOnLoad: true,
+						defaultSearch: JSON.stringify( {
+							searchText: 'astrolabe',
+						} ),
+						resultsPerPage: 40,
+						columns: 3,
+					},
+				} )
+			);
+		} );
+	};
+
+	it( 'sends the results per page setting as per_page', async () => {
+		await render( { 'X-WP-Page': '1', 'X-WP-TotalPages': '1' } );
+
+		const [ search ] = searchCalls();
+		expect( search ).toBeDefined();
+		expect( search.data ).toMatchObject( {
+			searchText: 'astrolabe',
+			per_page: 40,
+		} );
+		expect( search.data ).not.toHaveProperty( 'posts_per_page' );
+		expect( search.data ).not.toHaveProperty( 'numberposts' );
+	} );
+
+	it( 'reads the page count from the X-WP-TotalPages header', async () => {
+		await render( { 'X-WP-Page': '2', 'X-WP-TotalPages': '7' } );
+
+		// withPagination only renders controls when totalPages > 1, and only
+		// emits a jump-to-last-page button when totalPages exceeds the five
+		// pages it shows inline.
+		expect( container.innerHTML ).toContain( 'Go to page 7' );
+		expect( container.innerHTML ).toContain( 'aria-current="page"' );
+	} );
+
+	it( 'renders no pagination when the response carries no paging headers', async () => {
+		await render( {} );
+
+		expect( container.innerHTML ).not.toContain( 'Pagination Navigation' );
+	} );
+} );
+
+/**
+ * Load a view script in its own module registry (its work happens at import
+ * time) and let React commit the root it mounts.
+ */
+const bootstrap = async ( modulePath: string ) => {
+	jest.isolateModules( () => {
+		require( modulePath );
+	} );
+	// One turn for the fetch promise, one for the commit it schedules.
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+};
+
+describe( 'basic search block front end', () => {
+	it( 'sends per_page and paginates from the response headers', async () => {
+		mockApiFetch.mockImplementation( () =>
+			Promise.resolve(
+				restResponse( { 'X-WP-Page': '3', 'X-WP-TotalPages': '9' }, [] )
+			)
+		);
+
+		const element = document.createElement( 'div' );
+		element.className = 'wpm-basic-search-block-frontend';
+		element.dataset.attributes = JSON.stringify( {
+			searchText: 'astrolabe',
+			resultsPerPage: 40,
+			columns: 3,
+		} );
+		container.appendChild( element );
+
+		await bootstrap( '../../src/blocks/basic-search/front' );
+
+		const [ search ] = searchCalls();
+		expect( search ).toBeDefined();
+		expect( search.data ).toMatchObject( {
+			searchText: 'astrolabe',
+			per_page: 40,
+		} );
+		expect( search.data ).not.toHaveProperty( 'numberposts' );
+		expect( element.innerHTML ).toContain( 'Go to page 9' );
+		// EmbeddedSearch's title toggle renders a CheckboxControl, which emits
+		// an upstream margin-bottom deprecation notice.
+		expect( console ).toHaveWarned();
+	} );
+
+	// withPagination mutates and re-submits the object it is handed as
+	// `searchParams`. EmbeddedSearch builds a *fresh* params object for every
+	// search, so unless onSearch promotes what it searched to current state,
+	// paging re-submits the mount-time object — whose searchText is '' — and
+	// the block falls into the no-search branch that clears the results.
+	it( 'pages a user-entered search instead of blanking it', async () => {
+		mockApiFetch.mockImplementation( () =>
+			Promise.resolve(
+				restResponse( { 'X-WP-Page': '1', 'X-WP-TotalPages': '4' }, [] )
+			)
+		);
+
+		const element = document.createElement( 'div' );
+		element.className = 'wpm-basic-search-block-frontend';
+		element.dataset.attributes = JSON.stringify( {
+			searchText: '',
+			resultsPerPage: 20,
+			columns: 3,
+		} );
+		container.appendChild( element );
+
+		// The view script mounts its own root, so drive it through the DOM and
+		// let React commit between steps, as the bootstrap tests above do.
+		await bootstrap( '../../src/blocks/basic-search/front' );
+		expect( searchCalls() ).toHaveLength( 0 );
+
+		const settle = async () => {
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		};
+
+		// Type into the box and search, the way a visitor does.
+		const input = element.querySelector(
+			'input[type="text"]'
+		) as HTMLInputElement;
+		const setValue = Object.getOwnPropertyDescriptor(
+			window.HTMLInputElement.prototype,
+			'value'
+		)!.set!;
+		setValue.call( input, 'astrolabe' );
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		await settle();
+
+		(
+			element.querySelector(
+				'.wpm-embedded-search-button'
+			) as HTMLButtonElement
+		 ).click();
+		await settle();
+
+		expect( searchCalls() ).toHaveLength( 1 );
+		expect( element.innerHTML ).toContain( 'Go to page 4' );
+
+		const pageTwo = Array.from( element.querySelectorAll( 'button' ) ).find(
+			( button ) =>
+				button.getAttribute( 'aria-label' ) === 'Go to page 2'
+		);
+		expect( pageTwo ).toBeDefined();
+		pageTwo!.click();
+		await settle();
+
+		const calls = searchCalls();
+		expect( calls ).toHaveLength( 2 );
+		expect( calls[ 1 ].data ).toMatchObject( {
+			searchText: 'astrolabe',
+			page: 2,
+			per_page: 20,
+		} );
+		// The results (and therefore the controls) survive the page change.
+		expect( element.innerHTML ).toContain( 'Go to page 4' );
+		expect( console ).toHaveWarned();
+	} );
+} );
+
+describe( 'view script bootstrap without data-attributes', () => {
+	beforeEach( () => {
+		mockApiFetch.mockImplementation( () => new Promise( () => undefined ) );
+	} );
+
+	it( 'mounts the basic search block', async () => {
+		const element = document.createElement( 'div' );
+		element.className = 'wpm-basic-search-block-frontend';
+		container.appendChild( element );
+
+		await bootstrap( '../../src/blocks/basic-search/front' );
+
+		expect( element.innerHTML ).toContain( 'wpm-basic-search-block' );
+		// EmbeddedSearch's title toggle renders a CheckboxControl, which emits
+		// an upstream margin-bottom deprecation notice.
+		expect( console ).toHaveWarned();
+	} );
+
+	it( 'mounts the embedded search block', async () => {
+		const element = document.createElement( 'div' );
+		element.className = 'wpm-embedded-search-block-frontend';
+		container.appendChild( element );
+
+		await bootstrap( '../../src/blocks/embedded-search/front' );
+
+		expect( element.innerHTML ).toContain( 'wpm-embedded-search-block' );
+	} );
+} );

--- a/tests/unit/search-ui.test.tsx
+++ b/tests/unit/search-ui.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Regression tests for the advanced-search UI and the search modal.
+ *
+ * Two pre-existing bugs are covered here:
+ *
+ * 1. AdvancedSearchUI looked its selected kind up with
+ *    `kindItem.kind_id === selectedKind`. kind_id is an integer (see the
+ *    'kind_id' schema entry in src/rest/class-kinds-controller.php) while
+ *    SelectControl's onChange always hands back a string, so the lookup found
+ *    nothing after the user picked a kind and the following non-null
+ *    assertion threw — the field list never updated.
+ *
+ * 2. SearchBox called fetchSearchResults with two arguments in the delayed
+ *    (setTimeout) path, while both implementations dereference the
+ *    updateLastRefresh and updateResults callbacks, so the debounced search
+ *    threw a TypeError and results never arrived.
+ *
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/147
+ * @see https://github.com/Epistemic-Technology/wp-museum/issues/148
+ */
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+import AdvancedSearchUI from '../../src/components/advanced-search-ui/advanced-search-ui';
+import { SearchBox } from '../../src/components/search-modal/search-modal';
+
+import type { ObjectKind } from '../../src/types';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn( () => new Promise( () => undefined ) ),
+} ) );
+
+// SelectControl and ToggleControl emit deprecation notices for their default
+// sizing props, which @wordpress/jest-console turns into test failures.
+jest.mock( '@wordpress/deprecated', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+( global as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean } ).IS_REACT_ACT_ENVIRONMENT =
+	true;
+
+const kind = ( kindId: number, typeName: string, label: string ): ObjectKind =>
+	( {
+		kind_id: kindId,
+		type_name: typeName,
+		label,
+		label_plural: label + 's',
+	} as unknown as ObjectKind );
+
+/** Set an input/select value the way a user would, so React sees the change. */
+const setNativeValue = ( element: HTMLElement, value: string ) => {
+	const prototype =
+		element instanceof HTMLSelectElement
+			? HTMLSelectElement.prototype
+			: HTMLInputElement.prototype;
+	const setter = Object.getOwnPropertyDescriptor( prototype, 'value' )?.set;
+	setter?.call( element, value );
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach( () => {
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	root = createRoot( container );
+} );
+
+afterEach( () => {
+	act( () => root.unmount() );
+	container.remove();
+} );
+
+describe( 'AdvancedSearchUI kind selection', () => {
+	const kindsData = [
+		kind( 1, 'wpm_instrument', 'Instrument' ),
+		kind( 2, 'wpm_book', 'Book' ),
+	];
+
+	const renderUI = ( getFieldData: jest.Mock ) =>
+		act( async () => {
+			root.render(
+				<AdvancedSearchUI
+					showObjectType={ true }
+					getFieldData={ getFieldData }
+					kindsData={ kindsData }
+					collectionData={ [] }
+					onSearch={ () => undefined }
+				/>
+			);
+		} );
+
+	it( 'loads fields for the first kind before anything is selected', async () => {
+		const getFieldData = jest.fn( () => Promise.resolve( {} ) );
+
+		await renderUI( getFieldData );
+
+		expect( getFieldData ).toHaveBeenCalledWith( 'wpm_instrument' );
+	} );
+
+	it( 'loads fields for a kind the user picks from the select', async () => {
+		const getFieldData = jest.fn( () => Promise.resolve( {} ) );
+
+		await renderUI( getFieldData );
+		getFieldData.mockClear();
+
+		const select = container.querySelector(
+			'.advanced-search-object-type select'
+		) as HTMLSelectElement;
+		expect( select ).not.toBeNull();
+
+		await act( async () => {
+			setNativeValue( select, '2' );
+			select.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		// The select hands back the string '2'; the lookup must still find
+		// kind_id 2 and fetch that kind's fields.
+		expect( getFieldData ).toHaveBeenCalledWith( 'wpm_book' );
+	} );
+} );
+
+describe( 'SearchBox debounced fetch', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'passes the refresh and results callbacks on the delayed search', () => {
+		const fetchSearchResults = jest.fn();
+
+		act( () => {
+			root.render(
+				<SearchBox
+					fetchSearchResults={ fetchSearchResults }
+					close={ () => undefined }
+					returnCallback={ () => undefined }
+				/>
+			);
+		} );
+
+		const input = document.body.querySelector(
+			'#wpm-search-input'
+		) as HTMLInputElement;
+		expect( input ).not.toBeNull();
+
+		act( () => {
+			setNativeValue( input, 'tel' );
+			input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		// Nothing fires immediately: the modal has just mounted, so the last
+		// refresh is more recent than refreshInterval.
+		expect( fetchSearchResults ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.advanceTimersByTime( 500 );
+		} );
+
+		expect( fetchSearchResults ).toHaveBeenCalledTimes( 1 );
+		const [ searchText, onlyTitle, updateLastRefresh, updateResults ] =
+			fetchSearchResults.mock.calls[ 0 ];
+		expect( searchText ).toBe( 'tel' );
+		expect( onlyTitle ).toBe( true );
+		expect( typeof updateLastRefresh ).toBe( 'function' );
+		expect( typeof updateResults ).toBe( 'function' );
+
+		// The results callback the delayed search receives really does drive
+		// the results list.
+		act( () => {
+			updateResults( [ { ID: 12, post_title: 'Telescope' } ] );
+		} );
+
+		expect( document.body.textContent ).toContain( 'Telescope' );
+	} );
+
+	it( 'refreshes results when the title-only toggle is flipped', () => {
+		const fetchSearchResults = jest.fn();
+
+		act( () => {
+			root.render(
+				<SearchBox
+					fetchSearchResults={ fetchSearchResults }
+					close={ () => undefined }
+					returnCallback={ () => undefined }
+				/>
+			);
+		} );
+
+		const input = document.body.querySelector(
+			'#wpm-search-input'
+		) as HTMLInputElement;
+
+		act( () => {
+			setNativeValue( input, 'tel' );
+			input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+		fetchSearchResults.mockClear();
+
+		const toggle = document.body.querySelector(
+			'.toggle-control input[type="checkbox"]'
+		) as HTMLInputElement;
+		expect( toggle ).not.toBeNull();
+
+		act( () => {
+			toggle.click();
+		} );
+
+		expect( fetchSearchResults ).toHaveBeenCalledTimes( 1 );
+		const call = fetchSearchResults.mock.calls[ 0 ];
+		expect( call[ 0 ] ).toBe( 'tel' );
+		expect( call[ 1 ] ).toBe( false );
+		expect( typeof call[ 2 ] ).toBe( 'function' );
+		expect( typeof call[ 3 ] ).toBe( 'function' );
+	} );
+} );


### PR DESCRIPTION
Addresses most of #147 (preserved bugs) and #148 (possible-null-at-runtime sites). 51 of the 62 `TODO(ts-migration)` / `TODO(strict)` markers are resolved; the 8 that remain are deliberate and explained below.

**Based on `button-variant-cleanup` (#150), not `main`** — the `setAttributes!` marker in `advanced-search-ui.tsx` sits two lines from a Button changed there, so basing on `main` guarantees a conflict. Merge #150 first.

## What changes behavior

Every one of these was a real defect, verified against the PHP controllers and the wire types rather than taken from the TODO comment:

- **Field validation in object-meta has never run.** `checkAllFields` iterated `Object.entries()` and handed each `[field_id, field]` tuple to a function that destructures `slug`/`name`/`required`/`field_schema` off its argument, so all four were `undefined` and every check was a no-op. It now passes the field objects. The checks are advisory — nothing calls `lockPostSaving` — but this changes what the editor displays, so the load-time pass skips empty fields on a new object rather than flagging every required field before the curator types anything.
- **Results-per-page did nothing.** The search blocks sent `posts_per_page`/`numberposts`; `Objects_Controller::get_items()` reads `per_page`. The only reader of the old names is `do_advanced_search()`, which is never called.
- **Pagination never appeared.** The blocks looked for a `query_data` key the controller does not emit (the REST schema strips it). Paging now comes from the `X-WP-Page` / `X-WP-TotalPages` headers, matching the collection-objects block.
- **Image sizes were picked with transposed dimensions.** `getBestImage` destructured `[url, width, height, is_resized]` as `[URL, height, width, …]`. No consumer compensated for it.
- **Kind selection never matched.** `selectedKind` is a string once picked in the SelectControl; `kind_id` is a number; the `===` never matched, so field data never loaded for a user-selected kind.
- The debounced search in `SearchBox` threw (two arguments passed where four are dereferenced), so it silently never worked.

Plus the null dereferences from #148: load races on `objectKinds!`/`fieldData!`, nullable `kind_id`/`dimensions`/`thumbnail`/`full`, missing `dataset.*` attributes parsing as `NaN`, and `ObjectModal` crashing when opened before its images arrived.

## Review note

Every change was reviewed adversarially before landing, and several were reworked as a result — including one that would have made clicking any pagination control blank the search results, which is worse than the inert pagination it replaced. That one now has a regression test that fails without the fix.

## Deliberately not fixed — 8 markers remain

- **`feature-collection-widget`** — the marker is right that `collections` is a `{termId: termName}` map rather than an array of ids, but the keys are taxonomy *term* ids while `FeaturedCollection` fetches `/collections/{id}` by collection *post* id, and `Collections_Controller::get_post()` does not check `post_type`. Iterating the keys would render an arbitrary post as a featured collection. Needs a server-side mapping.
- **`object-image` `imgAlignment`** — read by `save()` but never registered in `block.json`, so it cannot persist. A real fix needs the attribute registered plus a deprecation entry, or every saved block invalidates.
- **`selectedKind`** — `/search` has no parameter for restricting by kind; the per-kind routes are GET-only.
- **4 markers in `museum-remote/src/`** — outside the scope covered here.

## Verification

- `npm run typecheck` clean (main and Playwright configs); `npm run build` succeeds.
- Unit tests: **56 passing, up from 21** — 35 new across six new files.
- e2e, full suite, same command on both: base 28 passed / 17 failed, this branch **32 passed / 14 failed**. The branch's failures are a strict subset of the base's — **no regressions**. The suite has pre-existing cross-spec state leakage unrelated to this work.

## Worth checking before merge

Fixing `getBestImage` changes which file is selected for non-square `imgDimensions`, and `ImageSelector` writes those dimensions into the persisted `imgHeight`/`imgWidth` attributes of `object-image` and `object-infobox`. Existing posts containing those blocks will be marked dirty the first time they are opened. Not block invalidation — neither attribute declares a `source`, and `save()` renders from `imgDimensions` — but it is real churn in saved content, so opening one such post first is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)